### PR TITLE
The ability to set a global user agent

### DIFF
--- a/Classes/ASIHTTPRequest.h
+++ b/Classes/ASIHTTPRequest.h
@@ -168,6 +168,9 @@ extern unsigned long const ASIWWANBandwidthThrottleAmount;
 	NSString *username;
 	NSString *password;
 	
+	// Global User-Agent for requests unless one is provided for a specific request
+	NSString *userAgent;
+	
 	// Domain used for NTLM authentication
 	NSString *domain;
 	
@@ -672,6 +675,7 @@ extern unsigned long const ASIWWANBandwidthThrottleAmount;
 // Will be used as a user agent if requests do not specify a custom user agent
 // Is only used when you have specified a Bundle Display Name (CFDisplayBundleName) or Bundle Name (CFBundleName) in your plist
 + (NSString *)defaultUserAgentString;
++ (void)setDefaultUserAgent:(NSString *)agent;
 
 #pragma mark proxy autoconfiguration
 
@@ -767,6 +771,7 @@ extern unsigned long const ASIWWANBandwidthThrottleAmount;
 
 @property (retain) NSString *username;
 @property (retain) NSString *password;
+@property (retain) NSString *userAgent;
 @property (retain) NSString *domain;
 
 @property (retain) NSString *proxyUsername;

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -3689,6 +3689,11 @@ static NSOperationQueue *sharedQueue = nil;
 
 + (NSString *)defaultUserAgentString
 {
+	// Return global user agent if provided
+	if (userAgent) {
+		return userAgent;
+	}
+	
 	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
 
 	// Attempt to find a name for this application
@@ -3745,6 +3750,16 @@ static NSOperationQueue *sharedQueue = nil;
 #endif
 	// Takes the form "My Application 1.0 (Macintosh; Mac OS X 10.5.7; en_GB)"
 	return [NSString stringWithFormat:@"%@ %@ (%@; %@ %@; %@)", appName, appVersion, deviceName, OSName, OSVersion, locale];
+}
+
++ (NSString *)userAgent
+{
+	return userAgent;
+}
+
++ (void)setDefaultUserAgent:(NSString *)agent
+{
+	userAgent = [agent copy];
 }
 
 #pragma mark proxy autoconfiguration
@@ -4157,6 +4172,7 @@ static NSOperationQueue *sharedQueue = nil;
 
 @synthesize username;
 @synthesize password;
+@synthesize userAgent;
 @synthesize domain;
 @synthesize proxyUsername;
 @synthesize proxyPassword;


### PR DESCRIPTION
The need to set a global user agent for an application can come up, and when there are multiple ASIHTTPRequests it gets cumbersome to have to manually set the User-Agent for each request:

```
[request addRequestHeader:@"User-Agent" value:[NSString stringWithFormat:@"CE API v%@", kCEAPIVersion]];
```

In the commit you'll see its now possible to set a global User-Agent which can still be overwritten on a per request basis. If this was merged, you'll be able to do the following instead:

```
[ASIHTTPRequest setUserAgent:[NSString stringWithFormat:@"CE API v%@", kCEAPIVersion]];
```
