### PR TITLE
Allow compiling with Clang/ObjC 2.0 ABI

### DIFF
--- a/Classes/ASIAuthenticationDialog.m
+++ b/Classes/ASIAuthenticationDialog.m
@@ -51,20 +51,20 @@ static const NSUInteger kDomainSection = 1;
 	}
 }
 
-+ (void)presentAuthenticationDialogForRequest:(ASIHTTPRequest *)request
++ (void)presentAuthenticationDialogForRequest:(ASIHTTPRequest *)theRequest
 {
 	// No need for a lock here, this will always be called on the main thread
 	if (!sharedDialog) {
 		sharedDialog = [[self alloc] init];
-		[sharedDialog setRequest:request];
-		if ([request authenticationNeeded] == ASIProxyAuthenticationNeeded) {
+		[sharedDialog setRequest:theRequest];
+		if ([theRequest authenticationNeeded] == ASIProxyAuthenticationNeeded) {
 			[sharedDialog setType:ASIProxyAuthenticationType];
 		} else {
 			[sharedDialog setType:ASIStandardAuthenticationType];
 		}
 		[sharedDialog show];
 	} else {
-		[requestsNeedingAuthentication addObject:request];
+		[requestsNeedingAuthentication addObject:theRequest];
 	}
 }
 

--- a/Classes/ASIInputStream.m
+++ b/Classes/ASIInputStream.m
@@ -21,20 +21,20 @@ static NSLock *readLock = nil;
 	}
 }
 
-+ (id)inputStreamWithFileAtPath:(NSString *)path request:(ASIHTTPRequest *)request
++ (id)inputStreamWithFileAtPath:(NSString *)path request:(ASIHTTPRequest *)theRequest
 {
-	ASIInputStream *stream = [[[self alloc] init] autorelease];
-	[stream setRequest:request];
-	[stream setStream:[NSInputStream inputStreamWithFileAtPath:path]];
-	return stream;
+	ASIInputStream *theStream = [[[self alloc] init] autorelease];
+	[theStream setRequest:theRequest];
+	[theStream setStream:[NSInputStream inputStreamWithFileAtPath:path]];
+	return theStream;
 }
 
-+ (id)inputStreamWithData:(NSData *)data request:(ASIHTTPRequest *)request
++ (id)inputStreamWithData:(NSData *)data request:(ASIHTTPRequest *)theRequest
 {
-	ASIInputStream *stream = [[[self alloc] init] autorelease];
-	[stream setRequest:request];
-	[stream setStream:[NSInputStream inputStreamWithData:data]];
-	return stream;
+	ASIInputStream *theStream = [[[self alloc] init] autorelease];
+	[theStream setRequest:theRequest];
+	[theStream setStream:[NSInputStream inputStreamWithData:data]];
+	return theStream;
 }
 
 - (void)dealloc


### PR DESCRIPTION
asi-http-request currently cannot be compiled using the Obj-C 2.0 ABI because it crashes Clang; the class methods in ASIInputStream and ASIAuthenticationDialog have duplicate names for their arguments and the class' ivars.  Clang does not like this.

On iOS and 64-bit OS X 10.6, the `-Xclang -fobjc-nonfragile-abi2` compiler flag has the practical upshot of not requiring @synthesize nor ivar defining for `@property` declaration.  This pull request fixes the compiling errors only, but does not make use of any of the 2.0 ABI features (removing `@synthesize`'s) so that it can compile in both kinds of projects.

Xcode 4 also uses the Obj-C 2.0 ABI (even for 32-bit platforms), so this is a futurepproofing move so that asi-http-request compiles now and later.
