### PR TITLE
Validation of self-signed certificates

### DIFF
--- a/Classes/ASIHTTPRequest.h
+++ b/Classes/ASIHTTPRequest.h
@@ -57,7 +57,8 @@ typedef enum _ASINetworkErrorType {
 	ASIFileManagementError = 8,
 	ASITooMuchRedirectionErrorType = 9,
 	ASIUnhandledExceptionError = 10,
-	ASICompressionError = 11
+	ASICompressionError = 11,
+	ASICertificateValidationErrorType = 12
 	
 } ASINetworkErrorType;
 
@@ -357,6 +358,8 @@ typedef void (^ASIDataBlock)(NSData *data);
 	
 	// When NO, requests will not check the secure certificate is valid (use for self-signed certificates during development, DO NOT USE IN PRODUCTION) Default is YES
 	BOOL validatesSecureCertificate;
+	BOOL hasPerformedServerCertificateValidation;
+	NSArray *additionalAnchorCertificates;
     
     // If not nil and the URL scheme is https, CFNetwork configured to supply a client certificate
     SecIdentityRef clientCertificateIdentity;
@@ -726,9 +729,10 @@ typedef void (^ASIDataBlock)(NSData *data);
 + (NSTimeInterval)defaultTimeOutSeconds;
 + (void)setDefaultTimeOutSeconds:(NSTimeInterval)newTimeOutSeconds;
 
-#pragma mark client certificate
+#pragma mark certificate handling
 
 - (void)setClientCertificateIdentity:(SecIdentityRef)anIdentity;
+- (void)validateServerCertificateWithAdditionalAnchorCertificates:(NSArray *)certificates;
 
 #pragma mark session credentials
 

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -3648,20 +3648,25 @@ static NSOperationQueue *sharedQueue = nil;
   // get the trust from the stream
   trust = (SecTrustRef)CFReadStreamCopyProperty((CFReadStreamRef)[self readStream], kCFStreamPropertySSLPeerTrust);
   
-  // add any additional anchor certificates that were provided
-  SecTrustSetAnchorCertificates(trust, (CFArrayRef)additionalAnchorCertificates);
-  
-  // evaluate trust on the server cert
-  returnCode = SecTrustEvaluate(trust, &result);
-  
-  if( returnCode == errSecSuccess ) {
-    success = (result == kSecTrustResultProceed || result == kSecTrustResultConfirm || result == kSecTrustResultUnspecified);
-    if( result == kSecTrustResultRecoverableTrustFailure ) {
-      // TODO: should try to recover here, per http://developer.apple.com/library/ios/documentation/Security/Reference/certifkeytrustservices/Reference/reference.html#//apple_ref/doc/uid/TP30000157-CH1g-CJBHFGHI
+  if( trust ) {
+    // add any additional anchor certificates that were provided
+    SecTrustSetAnchorCertificates(trust, (CFArrayRef)additionalAnchorCertificates);
+    
+    // evaluate trust on the server cert
+    returnCode = SecTrustEvaluate(trust, &result);
+    
+    if( returnCode == errSecSuccess ) {
+      success = (result == kSecTrustResultProceed || result == kSecTrustResultConfirm || result == kSecTrustResultUnspecified);
+      if( result == kSecTrustResultRecoverableTrustFailure ) {
+        // TODO: should try to recover here, per http://developer.apple.com/library/ios/documentation/Security/Reference/certifkeytrustservices/Reference/reference.html#//apple_ref/doc/uid/TP30000157-CH1g-CJBHFGHI
+      }
     }
+    
+    CFRelease(trust);
   }
-  
-  CFRelease(trust);
+  else {
+    success = YES;
+  }
   
   // did the trust evaluation succeed?
   if( !success ) {


### PR DESCRIPTION
In some ways, this is more of a sketch of the necessary changes, because I'm not sure that I'm implementing this in your idiom. But I'm happy to help flesh it out, too, if you have suggestions.

I'll start with some example code from a consumer app that would use the changes I've made:
    NSData\* certData = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"publickey" ofType:@"cer"]];
    SecCertificateRef cert = SecCertificateCreateWithData(NULL, (CFDataRef)certData);
    ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:@"https://mysecureserver.example.com/"]];
    [request validateServerCertificateWithAdditionalAnchorCertificates:[NSArray arrayWithObject:(id)cert]];
    [request setDelegate:self];
    [request startAsynchronous];

So, I've exported the public key for my certificate as a .cer file, and added it as a bundle resource of my app. I read in that file, instantiate the certificate, and then pass it to the new public method of ASIHTTPRequest.

Following [Quinn's advice from the Apple Dev Forums](https://devforums.apple.com/message/331446), if that array of additional certificates is populated, SSL validation is turned off on the stream properties. Then, the first time that `-[handleBytesAvailable]` is called, it calls a new private method `-[performServerCertificateValidation]` to perform the actual certificate validation.

I wasn't sure the best way to fit this in with the existing `validatesSecureCertificate` property. As this code stands, that flag still controls whether validation is performed, period. If it's not set, the new validation is a no-op. If it is set, but the list of additional anchor certs is non-empty, then the stream's validation property is set to false, as I mentioned.

I'm also not sure whether this really needs its own new error code, but I've erred on the site of specificity.

Lastly, there are probably also some places where these settings need to be copied to other places (I'm looking at, say, `-[HEADRequest]` and `-[copyWithZone:]`).
