### PR TITLE
Don't use the cached response if the server didn't send an explicit expiration time

### DIFF
--- a/Classes/ASIDownloadCache.m
+++ b/Classes/ASIDownloadCache.m
@@ -291,9 +291,9 @@ static NSString *permanentCacheFolder = @"PermanentStore";
 		// Look for an Expires header to see if the content is out of date
 		NSString *expires = [cachedHeaders objectForKey:@"Expires"];
 		if (expires) {
-			if ([[ASIHTTPRequest dateFromRFC1123String:expires] timeIntervalSinceNow] < 0) {
+			if ([[ASIHTTPRequest dateFromRFC1123String:expires] timeIntervalSinceNow] >= 0) {
 				[[self accessLock] unlock];
-				return NO;
+				return YES;
 			}
 		}
 		// Look for a max-age header
@@ -308,13 +308,15 @@ static NSString *permanentCacheFolder = @"PermanentStore";
 
 				NSDate *expiryDate = [[[NSDate alloc] initWithTimeInterval:maxAge sinceDate:fetchDate] autorelease];
 
-				if ([expiryDate timeIntervalSinceNow] < 0) {
+				if ([expiryDate timeIntervalSinceNow] >= 0) {
 					[[self accessLock] unlock];
-					return NO;
+					return YES;
 				}
 			}
 		}
 		
+		// No explicit expiration time sent by the server
+		return NO;
 	}
 	
 


### PR DESCRIPTION
The problem with the current code is that servers that do not send an explicit expiration time (`Expires` or `Cache-control: max-age=N` headers) for a file result in that file never being expired, even with a cache policy of `ASIAskServerIfModifiedWhenStaleCachePolicy`.

[The spec](http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html) states that in such cases, a heuristic may be used to define an expiration time based on other headers (e.g. `Last-Modified`) but that falls outside the scope of this patch, which simply tries to fallback to a conditional GET check in such cases.
