### PR TITLE
Fix XCode 3.2.5 / iOS 4.2 Build Problems

### DIFF
--- a/Classes/ASIAuthenticationDialog.m
+++ b/Classes/ASIAuthenticationDialog.m
@@ -51,20 +51,20 @@ static const NSUInteger kDomainSection = 1;
 	}
 }
 
-+ (void)presentAuthenticationDialogForRequest:(ASIHTTPRequest *)request
++ (void)presentAuthenticationDialogForRequest:(ASIHTTPRequest *)theRequest
 {
 	// No need for a lock here, this will always be called on the main thread
 	if (!sharedDialog) {
 		sharedDialog = [[self alloc] init];
-		[sharedDialog setRequest:request];
-		if ([request authenticationNeeded] == ASIProxyAuthenticationNeeded) {
+		[sharedDialog setRequest:theRequest];
+		if ([theRequest authenticationNeeded] == ASIProxyAuthenticationNeeded) {
 			[sharedDialog setType:ASIProxyAuthenticationType];
 		} else {
 			[sharedDialog setType:ASIStandardAuthenticationType];
 		}
 		[sharedDialog show];
 	} else {
-		[requestsNeedingAuthentication addObject:request];
+		[requestsNeedingAuthentication addObject:theRequest];
 	}
 }
 

--- a/Classes/ASIAuthenticationDialog.m
+++ b/Classes/ASIAuthenticationDialog.m
@@ -450,7 +450,7 @@ static const NSUInteger kDomainSection = 1;
 	return cell;
 }
 
-- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+- (NSInteger)tableView:(UITableView *)aTableView numberOfRowsInSection:(NSInteger)section
 {
 	if (section == 0) {
 		return 2;

--- a/Classes/ASIInputStream.m
+++ b/Classes/ASIInputStream.m
@@ -21,20 +21,20 @@ static NSLock *readLock = nil;
 	}
 }
 
-+ (id)inputStreamWithFileAtPath:(NSString *)path request:(ASIHTTPRequest *)request
++ (id)inputStreamWithFileAtPath:(NSString *)path request:(ASIHTTPRequest *)theRequest
 {
-	ASIInputStream *stream = [[[self alloc] init] autorelease];
-	[stream setRequest:request];
-	[stream setStream:[NSInputStream inputStreamWithFileAtPath:path]];
-	return stream;
+	ASIInputStream *theStream = [[[self alloc] init] autorelease];
+	[theStream setRequest:theRequest];
+	[theStream setStream:[NSInputStream inputStreamWithFileAtPath:path]];
+	return theStream;
 }
 
-+ (id)inputStreamWithData:(NSData *)data request:(ASIHTTPRequest *)request
++ (id)inputStreamWithData:(NSData *)data request:(ASIHTTPRequest *)theRequest
 {
-	ASIInputStream *stream = [[[self alloc] init] autorelease];
-	[stream setRequest:request];
-	[stream setStream:[NSInputStream inputStreamWithData:data]];
-	return stream;
+	ASIInputStream *theStream = [[[self alloc] init] autorelease];
+	[theStream setRequest:theRequest];
+	[theStream setStream:[NSInputStream inputStreamWithData:data]];
+	return theStream;
 }
 
 - (void)dealloc

--- a/Classes/S3/ASIS3Bucket.m
+++ b/Classes/S3/ASIS3Bucket.m
@@ -11,11 +11,11 @@
 
 @implementation ASIS3Bucket
 
-+ (id)bucketWithOwnerID:(NSString *)ownerID ownerName:(NSString *)ownerName
++ (id)bucketWithOwnerID:(NSString *)anOwnerID ownerName:(NSString *)anOwnerName
 {
 	ASIS3Bucket *bucket = [[[self alloc] init] autorelease];
-	[bucket setOwnerID:ownerID];
-	[bucket setOwnerName:ownerName];
+	[bucket setOwnerID:anOwnerID];
+	[bucket setOwnerName:anOwnerName];
 	return bucket;
 }
 

--- a/Classes/S3/ASIS3BucketObject.m
+++ b/Classes/S3/ASIS3BucketObject.m
@@ -11,10 +11,10 @@
 
 @implementation ASIS3BucketObject
 
-+ (id)objectWithBucket:(NSString *)bucket
++ (id)objectWithBucket:(NSString *)theBucket
 {
 	ASIS3BucketObject *object = [[[self alloc] init] autorelease];
-	[object setBucket:bucket];
+	[object setBucket:theBucket];
 	return object;
 }
 

--- a/Classes/S3/ASIS3BucketRequest.m
+++ b/Classes/S3/ASIS3BucketRequest.m
@@ -28,32 +28,32 @@
 	return self;
 }
 
-+ (id)requestWithBucket:(NSString *)bucket
++ (id)requestWithBucket:(NSString *)theBucket
 {
 	ASIS3BucketRequest *request = [[[self alloc] initWithURL:nil] autorelease];
-	[request setBucket:bucket];
+	[request setBucket:theBucket];
 	return request;
 }
 
-+ (id)requestWithBucket:(NSString *)bucket subResource:(NSString *)subResource
++ (id)requestWithBucket:(NSString *)theBucket subResource:(NSString *)theSubResource
 {
 	ASIS3BucketRequest *request = [[[self alloc] initWithURL:nil] autorelease];
-	[request setBucket:bucket];
-	[request setSubResource:subResource];
+	[request setBucket:theBucket];
+	[request setSubResource:theSubResource];
 	return request;
 }
 
-+ (id)PUTRequestWithBucket:(NSString *)bucket
++ (id)PUTRequestWithBucket:(NSString *)theBucket
 {
-	ASIS3BucketRequest *request = [self requestWithBucket:bucket];
+	ASIS3BucketRequest *request = [self requestWithBucket:theBucket];
 	[request setRequestMethod:@"PUT"];
 	return request;
 }
 
 
-+ (id)DELETERequestWithBucket:(NSString *)bucket
++ (id)DELETERequestWithBucket:(NSString *)theBucket
 {
-	ASIS3BucketRequest *request = [self requestWithBucket:bucket];
+	ASIS3BucketRequest *request = [self requestWithBucket:theBucket];
 	[request setRequestMethod:@"DELETE"];
 	return request;
 }

--- a/Classes/S3/ASIS3ObjectRequest.m
+++ b/Classes/S3/ASIS3ObjectRequest.m
@@ -21,62 +21,62 @@ NSString *const ASIS3StorageClassReducedRedundancy = @"REDUCED_REDUNDANCY";
 	return headRequest;
 }
 
-+ (id)requestWithBucket:(NSString *)bucket key:(NSString *)key
++ (id)requestWithBucket:(NSString *)theBucket key:(NSString *)theKey
 {
-	ASIS3ObjectRequest *request = [[[self alloc] initWithURL:nil] autorelease];
-	[request setBucket:bucket];
-	[request setKey:key];
-	return request;
+	ASIS3ObjectRequest *newRequest = [[[self alloc] initWithURL:nil] autorelease];
+	[newRequest setBucket:theBucket];
+	[newRequest setKey:theKey];
+	return newRequest;
 }
 
-+ (id)requestWithBucket:(NSString *)bucket key:(NSString *)key subResource:(NSString *)subResource
++ (id)requestWithBucket:(NSString *)theBucket key:(NSString *)theKey subResource:(NSString *)theSubResource
 {
-	ASIS3ObjectRequest *request = [[[self alloc] initWithURL:nil] autorelease];
-	[request setSubResource:subResource];
-	[request setBucket:bucket];
-	[request setKey:key];
-	return request;
+	ASIS3ObjectRequest *newRequest = [[[self alloc] initWithURL:nil] autorelease];
+	[newRequest setSubResource:theSubResource];
+	[newRequest setBucket:theBucket];
+	[newRequest setKey:theKey];
+	return newRequest;
 }
 
-+ (id)PUTRequestForData:(NSData *)data withBucket:(NSString *)bucket key:(NSString *)key
++ (id)PUTRequestForData:(NSData *)data withBucket:(NSString *)theBucket key:(NSString *)theKey
 {
-	ASIS3ObjectRequest *request = [self requestWithBucket:bucket key:key];
-	[request appendPostData:data];
-	[request setRequestMethod:@"PUT"];
-	return request;
+	ASIS3ObjectRequest *newRequest = [self requestWithBucket:theBucket key:theKey];
+	[newRequest appendPostData:data];
+	[newRequest setRequestMethod:@"PUT"];
+	return newRequest;
 }
 
-+ (id)PUTRequestForFile:(NSString *)filePath withBucket:(NSString *)bucket key:(NSString *)key
++ (id)PUTRequestForFile:(NSString *)filePath withBucket:(NSString *)theBucket key:(NSString *)theKey
 {
-	ASIS3ObjectRequest *request = [self requestWithBucket:bucket key:key];
-	[request setPostBodyFilePath:filePath];
-	[request setShouldStreamPostDataFromDisk:YES];
-	[request setRequestMethod:@"PUT"];
-	[request setMimeType:[ASIHTTPRequest mimeTypeForFileAtPath:filePath]];
-	return request;
+	ASIS3ObjectRequest *newRequest = [self requestWithBucket:theBucket key:theKey];
+	[newRequest setPostBodyFilePath:filePath];
+	[newRequest setShouldStreamPostDataFromDisk:YES];
+	[newRequest setRequestMethod:@"PUT"];
+	[newRequest setMimeType:[ASIHTTPRequest mimeTypeForFileAtPath:filePath]];
+	return newRequest;
 }
 
-+ (id)DELETERequestWithBucket:(NSString *)bucket key:(NSString *)key
++ (id)DELETERequestWithBucket:(NSString *)theBucket key:(NSString *)theKey
 {
-	ASIS3ObjectRequest *request = [self requestWithBucket:bucket key:key];
-	[request setRequestMethod:@"DELETE"];
-	return request;
+	ASIS3ObjectRequest *newRequest = [self requestWithBucket:theBucket key:theKey];
+	[newRequest setRequestMethod:@"DELETE"];
+	return newRequest;
 }
 
-+ (id)COPYRequestFromBucket:(NSString *)sourceBucket key:(NSString *)sourceKey toBucket:(NSString *)bucket key:(NSString *)key
++ (id)COPYRequestFromBucket:(NSString *)theSourceBucket key:(NSString *)theSourceKey toBucket:(NSString *)theBucket key:(NSString *)theKey
 {
-	ASIS3ObjectRequest *request = [self requestWithBucket:bucket key:key];
-	[request setRequestMethod:@"PUT"];
-	[request setSourceBucket:sourceBucket];
-	[request setSourceKey:sourceKey];
-	return request;
+	ASIS3ObjectRequest *newRequest = [self requestWithBucket:theBucket key:theKey];
+	[newRequest setRequestMethod:@"PUT"];
+	[newRequest setSourceBucket:theSourceBucket];
+	[newRequest setSourceKey:theSourceKey];
+	return newRequest;
 }
 
-+ (id)HEADRequestWithBucket:(NSString *)bucket key:(NSString *)key
++ (id)HEADRequestWithBucket:(NSString *)theBucket key:(NSString *)theKey
 {
-	ASIS3ObjectRequest *request = [self requestWithBucket:bucket key:key];
-	[request setRequestMethod:@"HEAD"];
-	return request;
+	ASIS3ObjectRequest *newRequest = [self requestWithBucket:theBucket key:theKey];
+	[newRequest setRequestMethod:@"HEAD"];
+	return newRequest;
 }
 
 - (id)copyWithZone:(NSZone *)zone


### PR DESCRIPTION
This builds on and extends pokeb#93. The requester's original commit is maintained, and you'll get both his commit and mine when you apply this single pull request.

Mine brings similar changes both to the S3 classes, as well as fixing up some methods that have `tableView` parameter names which cause similar conflicts.  pokeb#93 goes into better discussion of the reasons why this is beneficial, the only addition I'll make here is that it impacts XCode 3.2.5's use of LLVM, in addition to XCode 4.  That elevates it to a production SDK issue that affects the production path for iOS apps using ASI and compiling with LLVM (with massive source code implications, making it non-trivial to move away from LLVM and the non-fragile-abi).
