### PR TITLE
ASIDownloadCache bug fix

### DIFF
--- a/Classes/ASIDownloadCache.m
+++ b/Classes/ASIDownloadCache.m
@@ -273,6 +273,7 @@ static NSString *permanentCacheFolder = @"PermanentStore";
 
 		// New content is not different
 		if ([request responseStatusCode] == 304) {
+			[[self accessLock] unlock];
 			return YES;
 		}
 


### PR DESCRIPTION
Hi, ASIDownloadCache isn't unlocking it's accessLock when a 304 response status is received.  Have fixed in my fork, it's pretty crucial as we otherwise get deadlocks..

Thanks for all your hard work, the library is fantastic!

Cheers,
Jude
