### PR TITLE
No Basic Auth authorization header for Digest/NTLM schemes

### DIFF
--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -932,8 +932,8 @@ static NSOperationQueue *sharedQueue = nil;
 	// Are any credentials set on this request that might be used for basic authentication?
 	if ([self username] && [self password] && ![self domain]) {
 		
-		// If we have stored credentials, is this server asking for basic authentication? If we don't have credentials, we'll assume basic
-		if (!credentials || (CFStringRef)[credentials objectForKey:@"AuthenticationScheme"] == kCFHTTPAuthenticationSchemeBasic) {
+		// If we have stored credentials, is this server asking for basic authentication?
+		if ((CFStringRef)[credentials objectForKey:@"AuthenticationScheme"] == kCFHTTPAuthenticationSchemeBasic) {
 			[self addBasicAuthenticationHeaderWithUsername:[self username] andPassword:[self password]];
 		}
 	}


### PR DESCRIPTION
This patch makes sure no Basic Auth authorization is added when the scheme is Digest or NTLM with the default settings (i.e. shouldPresentCredentialsBeforeChallenge = YES).

Without this patch, when Digest scheme is enabled and the very first request is performed (i.e. no credentials found in the session store) a Basic Auth authorization header is added:
- this does not follow the official RFC (e.g. Rack 1.2.1 middleware breaks and return a 400 HTTP code)
- this sends clear credentials over the network, even if Digest is designed to not do so
