### PR TITLE
Pull request: Fix for addPostValue:forKey: of ASIFormDataRequest

### DIFF
--- a/Classes/ASIFormDataRequest.m
+++ b/Classes/ASIFormDataRequest.m
@@ -67,10 +67,17 @@
 
 - (void)addPostValue:(id <NSObject>)value forKey:(NSString *)key
 {
+	if (!key) {
+		return;
+	}
+	NSString *valueString = [value description];
+	if (!valueString) {
+		valueString = @"";
+	}
 	if (![self postData]) {
 		[self setPostData:[NSMutableArray array]];
 	}
-	[[self postData] addObject:[NSDictionary dictionaryWithObjectsAndKeys:[value description],@"value",key,@"key",nil]];
+	[[self postData] addObject:[NSDictionary dictionaryWithObjectsAndKeys:valueString,@"value",key,@"key",nil]];
 }
 
 - (void)setPostValue:(id <NSObject>)value forKey:(NSString *)key


### PR DESCRIPTION
Hi pokeb,
I found that the  addPostValue:forKey: method of ASIFormDataRequest is vulnerable when the given key or value is nil. Validating every arguments before passing them to this method was a bit annoying for me so I made this patch. Hope you find this useful :)

P.S. Thanks for this great boon for all iOS/Mac OS developers!
