### PR TITLE
NTLM HTTP Proxy

### DIFF
--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -2403,6 +2403,30 @@ static NSOperationQueue *sharedQueue = nil;
 	
 	// If we have a username and password, let's apply them to the request and continue
 	if (user && pass) {
+		// --- BEGIN adib 7-Jan-2011
+		// set domain for NTLM
+		{
+			NSString* authScheme = [self proxyAuthenticationScheme];
+			if ([authScheme isEqualToString:(NSString*) kCFHTTPAuthenticationSchemeNTLM]) {
+				NSString* ntlmDomain = [self proxyDomain];
+				if (!ntlmDomain || [ntlmDomain length] == 0) {
+					// try to extract the domain from the user name if its in the form DOMAIN\username
+					NSArray* ntlmComponents = [user componentsSeparatedByString:@"\\"];
+					if (ntlmComponents.count == 2) {
+						NSString* domainName = [ntlmComponents objectAtIndex:0];
+						NSString* userName = [ntlmComponents objectAtIndex:1];
+						
+						user = userName;
+						ntlmDomain = domainName;
+					}
+				}
+				if (ntlmDomain) {
+					[newCredentials setObject:ntlmDomain forKey: (NSString*) kCFHTTPAuthenticationAccountDomain];
+				}
+			}
+			
+		}
+		// --- END adib 7-Jan-2011
 		
 		[newCredentials setObject:user forKey:(NSString *)kCFHTTPAuthenticationUsername];
 		[newCredentials setObject:pass forKey:(NSString *)kCFHTTPAuthenticationPassword];


### PR DESCRIPTION
Hi,

Please merge back this commit into your source tree.  It contains support for HTTP Proxies that are authenticated via NTLM. The change is inside -[ASIHTTPRequest findProxyCredentials]

The problem is that in Snow Leopard there is no GUI to specify what is the NTLM domain and thus the domain needs to be put inside the username in the form DOMAIN\user (sample screenshot: https://skitch.com/adib/refsc/screen-shot-2011-01-07-at-15.09.50 ).  This patch checks whether the username contains a domain part and set it appropriately.  

Thank you.
