### PR TITLE
Bugfix in ASIDataCompressor / Decompressor

### DIFF
--- a/Classes/ASIDataCompressor.m
+++ b/Classes/ASIDataCompressor.m
@@ -83,7 +83,7 @@
 	NSError *theError = nil;
 	
 	NSInteger bytesProcessedAlready = zStream.total_out;
-	while (zStream.avail_out == 0) {
+	while (zStream.avail_in != 0) {
 		
 		if (zStream.total_out-bytesProcessedAlready >= [outputData length]) {
 			[outputData increaseLengthBy:halfLength];

--- a/Classes/ASIDataDecompressor.m
+++ b/Classes/ASIDataDecompressor.m
@@ -80,7 +80,7 @@
 	NSError *theError = nil;
 	
 	NSInteger bytesProcessedAlready = zStream.total_out;
-	while (zStream.avail_out == 0) {
+	while (zStream.avail_in != 0) {
 		
 		if (zStream.total_out-bytesProcessedAlready >= [outputData length]) {
 			[outputData increaseLengthBy:halfLength];


### PR DESCRIPTION
I discovered a bug that would manifest itself as a request failing with the error "Decompression of data failed with code -5".

-5 is Z_BUF_ERROR

This occurs in the decompression loop whenever the output perfectly fits into the buffer allocated.  Previously in this case we would try running through the loop once more, however the input buffer now contains zero more bytes.  This causes inflate() to return Z_BUF_ERROR.

The fix is to change the loop condition so that it is executed until there is no more input.

A similar problem could occur with data compression.

Regards,

Alex
