### PR TITLE
completionBlock need to be executing first.

### DIFF
--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -1940,17 +1940,17 @@ static NSOperationQueue *sharedQueue = nil;
 /* ALWAYS CALLED ON MAIN THREAD! */
 - (void)reportFinished
 {
+#if NS_BLOCKS_AVAILABLE
+	if(completionBlock){
+		completionBlock();
+	}
+#endif
 	if (delegate && [delegate respondsToSelector:didFinishSelector]) {
 		[delegate performSelector:didFinishSelector withObject:self];
 	}
 	if (queue && [queue respondsToSelector:@selector(requestFinished:)]) {
 		[queue performSelector:@selector(requestFinished:) withObject:self];
 	}
-#if NS_BLOCKS_AVAILABLE
-	if(completionBlock){
-		completionBlock();
-	}
-#endif
 }
 
 /* ALWAYS CALLED ON MAIN THREAD! */


### PR DESCRIPTION
Using this great library, i'm facing a minor problem when using request's completionBlock in a ASINetworkQueue.
The queue run "queueDidFinishSelector" before the request's "completionBlock" has been executed.

It would be more correct to execute completionblock before, isn't it ?
