### PR TITLE
ASIHTTPRequest : shouldCreateDestinationPath

### DIFF
--- a/Classes/ASIHTTPRequest.h
+++ b/Classes/ASIHTTPRequest.h
@@ -113,6 +113,9 @@ typedef void (^ASIDataBlock)(NSData *data);
 	// Automatically set to true in ASIFormDataRequests when using setFile:forKey:
 	BOOL shouldStreamPostDataFromDisk;
 	
+	// When true, the destination path will be created if it doesn't exist
+	BOOL shouldCreateDestinationPath;
+	
 	// Path to file used to store post body (when shouldStreamPostDataFromDisk is true)
 	// You can set this yourself - useful if you want to PUT a file from local disk 
 	NSString *postBodyFilePath;
@@ -911,6 +914,7 @@ typedef void (^ASIDataBlock)(NSData *data);
 @property (retain) NSString *downloadDestinationPath;
 @property (retain) NSString *temporaryFileDownloadPath;
 @property (retain) NSString *temporaryUncompressedDataDownloadPath;
+@property (assign) BOOL shouldCreateDestinationPath;
 @property (assign) SEL didStartSelector;
 @property (assign) SEL didReceiveResponseHeadersSelector;
 @property (assign) SEL willRedirectSelector;

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -3200,25 +3200,45 @@ static NSOperationQueue *sharedQueue = nil;
 		if ([self shouldRedirect] && [self needsRedirect] && [self allowResumeForFileDownloads]) {
 		
 		} else if ([self isResponseCompressed]) {
-			
-			// Decompress the file directly to the destination path
-			if ([self shouldWaitToInflateCompressedResponses]) {
-				[ASIDataDecompressor uncompressDataFromFile:[self temporaryFileDownloadPath] toFile:[self downloadDestinationPath] error:&fileError];
-
-			// Response should already have been inflated, move the temporary file to the destination path
-			} else {
-				NSError *moveError = nil;
-				[[[[NSFileManager alloc] init] autorelease] moveItemAtPath:[self temporaryUncompressedDataDownloadPath] toPath:[self downloadDestinationPath] error:&moveError];
-				if (moveError) {
-					fileError = [NSError errorWithDomain:NetworkRequestErrorDomain code:ASIFileManagementError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Failed to move file from '%@' to '%@'",[self temporaryFileDownloadPath],[self downloadDestinationPath]],NSLocalizedDescriptionKey,moveError,NSUnderlyingErrorKey,nil]];
+			NSFileManager *fileManager = [[[NSFileManager alloc] init] autorelease];
+			if ([self shouldCreateDestinationPath]) {
+				NSError *createPathError = nil;
+				NSString *path = [[self downloadDestinationPath] stringByDeletingLastPathComponent];
+				[fileManager createDirectoryAtPath:path withIntermediateDirectories:YES attributes:nil error:&createPathError];
+				if (createPathError) {
+					fileError = createPathError;
 				}
-				[self setTemporaryUncompressedDataDownloadPath:nil];
-
+			}
+			if (!fileError) {
+				// Decompress the file directly to the destination path
+				if ([self shouldWaitToInflateCompressedResponses]) {
+					[ASIDataDecompressor uncompressDataFromFile:[self temporaryFileDownloadPath] toFile:[self downloadDestinationPath] error:&fileError];
+					
+					// Response should already have been inflated, move the temporary file to the destination path
+				} else {
+					NSError *moveError = nil;
+					[[[[NSFileManager alloc] init] autorelease] moveItemAtPath:[self temporaryUncompressedDataDownloadPath] toPath:[self downloadDestinationPath] error:&moveError];
+					if (moveError) {
+						fileError = [NSError errorWithDomain:NetworkRequestErrorDomain code:ASIFileManagementError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Failed to move file from '%@' to '%@'",[self temporaryFileDownloadPath],[self downloadDestinationPath]],NSLocalizedDescriptionKey,moveError,NSUnderlyingErrorKey,nil]];
+					}
+					[self setTemporaryUncompressedDataDownloadPath:nil];
+					
+				}
 			}
 			[self removeTemporaryDownloadFile];
 
 		} else {
-	
+			NSFileManager *fileManager = [[[NSFileManager alloc] init] autorelease];
+			// Create the destination path if needed
+			if ([self shouldCreateDestinationPath]) {
+				NSError *createPathError = nil;
+				NSString *path = [[self downloadDestinationPath] stringByDeletingLastPathComponent];
+				[fileManager createDirectoryAtPath:path withIntermediateDirectories:YES attributes:nil error:&createPathError];
+				if (createPathError) {
+					fileError = createPathError;
+				}
+			}
+			
 			//Remove any file at the destination path
 			NSError *moveError = nil;
 			if (![[self class] removeFileAtPath:[self downloadDestinationPath] error:&moveError]) {
@@ -4676,6 +4696,7 @@ static NSOperationQueue *sharedQueue = nil;
 @synthesize didReceiveResponseHeadersSelector;
 @synthesize willRedirectSelector;
 @synthesize didFinishSelector;
+@synthesize shouldCreateDestinationPath;
 @synthesize didFailSelector;
 @synthesize didReceiveDataSelector;
 @synthesize authenticationRealm;


### PR DESCRIPTION
This property allows ASIHTTPRequest to create the destination path if it does not exists.
SImple, fast, no need to create dirs by ourselves
