### PR TITLE
Xcode 4 support and static lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ profile
 *.pbxuser
 *.mode1v3
 External/GHUnit/*
+xcuserdata

--- a/ASIHTTPRequest.xcworkspace/contents.xcworkspacedata
+++ b/ASIHTTPRequest.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Mac.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:iPhone.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:libasihttp.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/README.textile
+++ b/README.textile
@@ -30,3 +30,13 @@ It provides:
 ASIHTTPRequest is compatible with Mac OS 10.5 or later, and iOS 3.0 or later.
 
 Documentation is available "here":http://allseeing-i.com/ASIHTTPRequest.
+
+Xcode 4 installation
+
+# Create a workspace containing your app's project.
+# Add the libasihttp project to your workspace.
+# Add libasihttp.a to your target's "Link Binary With Libraries" build phase.
+# Add "$(BUILT_PRODUCTS_DIR)/asihttp" to your target's "User Header Search Paths" build setting.
+# Add the libasihttp build target to your scheme before your application's target.
+
+See "Using Open Source Static Libraries in Xcode 4":http://blog.carbonfive.com/2011/04/04/using-open-source-static-libraries-in-xcode-4/#using_a_static_library for a description of how to work with cross project dependencies within a workspace.

--- a/iPhone Sample/UploadViewController.m
+++ b/iPhone Sample/UploadViewController.m
@@ -70,14 +70,14 @@
         [[UIApplication sharedApplication] cancelAllLocalNotifications];
 
     // Create a new notification
-    UILocalNotification* alarm = [[[UILocalNotification alloc] init] autorelease];
-    if (alarm) {
-		[alarm setFireDate:[NSDate date]];
-		[alarm setTimeZone:[NSTimeZone defaultTimeZone]];
-		[alarm setRepeatInterval:0];
-		[alarm setSoundName:@"alarmsound.caf"];
-		[alarm setAlertBody:@"Boom!\r\n\r\nUpload is finished!"];
-        [[UIApplication sharedApplication] scheduleLocalNotification:alarm];
+    UILocalNotification* uploadFinishedAlarm = [[[UILocalNotification alloc] init] autorelease];
+    if (uploadFinishedAlarm) {
+		[uploadFinishedAlarm setFireDate:[NSDate date]];
+		[uploadFinishedAlarm setTimeZone:[NSTimeZone defaultTimeZone]];
+		[uploadFinishedAlarm setRepeatInterval:0];
+		[uploadFinishedAlarm setSoundName:@"alarmsound.caf"];
+		[uploadFinishedAlarm setAlertBody:@"Boom!\r\n\r\nUpload is finished!"];
+        [[UIApplication sharedApplication] scheduleLocalNotification:uploadFinishedAlarm];
     }
 	#endif
 }

--- a/iPhone.xcodeproj/project.pbxproj
+++ b/iPhone.xcodeproj/project.pbxproj
@@ -7,52 +7,38 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B50C1823121C26DB0055FCAB /* ClientCertificateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B50C1822121C26DB0055FCAB /* ClientCertificateTests.m */; };
+		8C7B4231134D239A00CAD6D3 /* libasihttp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C7B4230134D239A00CAD6D3 /* libasihttp.a */; };
+		8C7B4232134D23A600CAD6D3 /* libasihttp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C7B4230134D239A00CAD6D3 /* libasihttp.a */; };
+		8C7B4233134D23A700CAD6D3 /* libasihttp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C7B4230134D239A00CAD6D3 /* libasihttp.a */; };
+		8C7B4252134D2AD200CAD6D3 /* ASICloudFilesRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C7B4236134D2AD200CAD6D3 /* ASICloudFilesRequestTests.m */; };
+		8C7B4254134D2AD200CAD6D3 /* ASIDownloadCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C7B423A134D2AD200CAD6D3 /* ASIDownloadCacheTests.m */; };
+		8C7B4255134D2AD200CAD6D3 /* ASIFormDataRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C7B423C134D2AD200CAD6D3 /* ASIFormDataRequestTests.m */; };
+		8C7B4256134D2AD200CAD6D3 /* ASIHTTPRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C7B423E134D2AD200CAD6D3 /* ASIHTTPRequestTests.m */; };
+		8C7B4257134D2AD200CAD6D3 /* ASINetworkQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C7B4240134D2AD200CAD6D3 /* ASINetworkQueueTests.m */; };
+		8C7B4258134D2AD200CAD6D3 /* ASIS3RequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C7B4242134D2AD200CAD6D3 /* ASIS3RequestTests.m */; };
+		8C7B4259134D2AD200CAD6D3 /* ASITestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C7B4244134D2AD200CAD6D3 /* ASITestCase.m */; };
+		8C7B425A134D2AD200CAD6D3 /* ASIWebPageRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C7B4246134D2AD200CAD6D3 /* ASIWebPageRequestTests.m */; };
+		8C7B425B134D2AD200CAD6D3 /* BlocksTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C7B4248134D2AD200CAD6D3 /* BlocksTests.m */; };
+		8C7B425C134D2AD200CAD6D3 /* ClientCertificateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C7B424A134D2AD200CAD6D3 /* ClientCertificateTests.m */; };
+		8C7B425E134D2AD200CAD6D3 /* PerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C7B424D134D2AD200CAD6D3 /* PerformanceTests.m */; };
+		8C7B425F134D2AD200CAD6D3 /* ProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C7B424F134D2AD200CAD6D3 /* ProxyTests.m */; };
+		8C7B4260134D2AD200CAD6D3 /* StressTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C7B4251134D2AD200CAD6D3 /* StressTests.m */; };
 		B50C182C121C26FA0055FCAB /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B50C182B121C26FA0055FCAB /* Security.framework */; };
 		B50C1848121C27510055FCAB /* client.p12 in Resources */ = {isa = PBXBuildFile; fileRef = B50C1847121C27510055FCAB /* client.p12 */; };
-		B50D532C126C87ED0022EA6F /* BlocksTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B50D532B126C87ED0022EA6F /* BlocksTests.m */; };
 		B50F66191297FA45003887B1 /* strict.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = B50F66181297FA45003887B1 /* strict.xcconfig */; };
 		B50F661A1297FA45003887B1 /* strict.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = B50F66181297FA45003887B1 /* strict.xcconfig */; };
 		B50F661B1297FA45003887B1 /* strict.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = B50F66181297FA45003887B1 /* strict.xcconfig */; };
 		B51791A31024C3E800583567 /* AuthenticationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B51791A21024C3E800583567 /* AuthenticationViewController.m */; };
-		B51A1A9B11DDF85100ED75CF /* ASIDownloadCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B51A1A7A11DDF7BF00ED75CF /* ASIDownloadCacheTests.m */; };
-		B522DACE1030B2AB009A2D22 /* ASIInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = B522DACD1030B2AB009A2D22 /* ASIInputStream.m */; };
-		B522DACF1030B2AB009A2D22 /* ASIInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = B522DACD1030B2AB009A2D22 /* ASIInputStream.m */; };
 		B523254211CA01F1006C6E5A /* Sample.xib in Resources */ = {isa = PBXBuildFile; fileRef = B523254111CA01F1006C6E5A /* Sample.xib */; };
 		B523254311CA01F1006C6E5A /* Sample.xib in Resources */ = {isa = PBXBuildFile; fileRef = B523254111CA01F1006C6E5A /* Sample.xib */; };
 		B52325AD11CA05A8006C6E5A /* info.png in Resources */ = {isa = PBXBuildFile; fileRef = B52325AC11CA05A8006C6E5A /* info.png */; };
-		B5254FF91025F9BF00CF7BC4 /* ProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B5254FF71025F9BF00CF7BC4 /* ProxyTests.m */; };
-		B52D4A2F10DA4ED5008E8365 /* PerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B52D4A2E10DA4ED5008E8365 /* PerformanceTests.m */; };
-		B53E6D951257B45800C1E79A /* ASIDataDecompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = B53E6D911257B45800C1E79A /* ASIDataDecompressor.m */; };
-		B53E6D961257B45800C1E79A /* ASIDataCompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = B53E6D931257B45800C1E79A /* ASIDataCompressor.m */; };
-		B53E6D971257B45800C1E79A /* ASIDataDecompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = B53E6D911257B45800C1E79A /* ASIDataDecompressor.m */; };
-		B53E6D981257B45800C1E79A /* ASIDataCompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = B53E6D931257B45800C1E79A /* ASIDataCompressor.m */; };
-		B53E6D991257B45800C1E79A /* ASIDataDecompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = B53E6D911257B45800C1E79A /* ASIDataDecompressor.m */; };
-		B53E6D9A1257B45800C1E79A /* ASIDataCompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = B53E6D931257B45800C1E79A /* ASIDataCompressor.m */; };
-		B540400B115114BA00D8BE63 /* ASIS3Bucket.m in Sources */ = {isa = PBXBuildFile; fileRef = B5404000115114BA00D8BE63 /* ASIS3Bucket.m */; };
-		B540400C115114BA00D8BE63 /* ASIS3BucketRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B5404002115114BA00D8BE63 /* ASIS3BucketRequest.m */; };
-		B540400D115114BA00D8BE63 /* ASIS3ObjectRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B5404004115114BA00D8BE63 /* ASIS3ObjectRequest.m */; };
-		B540400E115114BA00D8BE63 /* ASIS3ServiceRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B5404006115114BA00D8BE63 /* ASIS3ServiceRequest.m */; };
-		B55252B411D22E2200F9B170 /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = B55252B311D22E2200F9B170 /* Reachability.m */; };
-		B55252B511D22E2200F9B170 /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = B55252B311D22E2200F9B170 /* Reachability.m */; };
-		B55252B611D22E2200F9B170 /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = B55252B311D22E2200F9B170 /* Reachability.m */; };
 		B558B5EB11C7F9C8009B4627 /* iPadMainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = B576D76311C7F4D40059B815 /* iPadMainWindow.xib */; };
-		B55B604D0F765A320064029C /* ASIFormDataRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60460F765A320064029C /* ASIFormDataRequest.m */; };
-		B55B604E0F765A320064029C /* ASIHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60480F765A320064029C /* ASIHTTPRequest.m */; };
-		B55B604F0F765A320064029C /* ASINetworkQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B604A0F765A320064029C /* ASINetworkQueue.m */; };
 		B55B60620F765A750064029C /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60600F765A750064029C /* main.m */; };
 		B55B606F0F765A930064029C /* QueueViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60670F765A930064029C /* QueueViewController.m */; };
 		B55B60700F765A930064029C /* SynchronousViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B606A0F765A930064029C /* SynchronousViewController.m */; };
 		B55B60710F765A930064029C /* iPhoneSampleAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B606B0F765A930064029C /* iPhoneSampleAppDelegate.m */; };
 		B55B60720F765A930064029C /* UploadViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B606C0F765A930064029C /* UploadViewController.m */; };
 		B55B60740F765A990064029C /* iphone-icon.png in Resources */ = {isa = PBXBuildFile; fileRef = B55B60730F765A990064029C /* iphone-icon.png */; };
-		B55B60CF0F765BBA0064029C /* ASIFormDataRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60460F765A320064029C /* ASIFormDataRequest.m */; };
-		B55B60D00F765BBD0064029C /* ASIHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60480F765A320064029C /* ASIHTTPRequest.m */; };
-		B55B60D10F765BC00064029C /* ASINetworkQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B604A0F765A320064029C /* ASINetworkQueue.m */; };
-		B55B60D30F765BC90064029C /* ASIFormDataRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60530F765A3C0064029C /* ASIFormDataRequestTests.m */; };
-		B55B60D40F765BCD0064029C /* ASIHTTPRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60550F765A3C0064029C /* ASIHTTPRequestTests.m */; };
-		B55B60D50F765BD00064029C /* ASINetworkQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60570F765A3C0064029C /* ASINetworkQueueTests.m */; };
-		B5652920101C8BD7000499CF /* ASITestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = B565291F101C8BD7000499CF /* ASITestCase.m */; };
 		B56529A3101C8EDA000499CF /* iphone-tests-icon.png in Resources */ = {isa = PBXBuildFile; fileRef = B56529A2101C8EDA000499CF /* iphone-tests-icon.png */; };
 		B576D4C111C7CC970059B815 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D4C011C7CC970059B815 /* CFNetwork.framework */; };
 		B576D4C411C7CC9C0059B815 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D4C311C7CC9C0059B815 /* UIKit.framework */; };
@@ -61,39 +47,19 @@
 		B576D4D111C7CCBC0059B815 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D4D011C7CCBC0059B815 /* CoreGraphics.framework */; };
 		B576D52D11C7CEFA0059B815 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D52C11C7CEFA0059B815 /* Foundation.framework */; };
 		B576D70411C7F34D0059B815 /* iphone-icon.png in Resources */ = {isa = PBXBuildFile; fileRef = B55B60730F765A990064029C /* iphone-icon.png */; };
-		B576D70B11C7F34D0059B815 /* ASIFormDataRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60460F765A320064029C /* ASIFormDataRequest.m */; };
-		B576D70C11C7F34D0059B815 /* ASIHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60480F765A320064029C /* ASIHTTPRequest.m */; };
-		B576D70D11C7F34D0059B815 /* ASINetworkQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B604A0F765A320064029C /* ASINetworkQueue.m */; };
 		B576D70F11C7F34D0059B815 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60600F765A750064029C /* main.m */; };
 		B576D71011C7F34D0059B815 /* QueueViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60670F765A930064029C /* QueueViewController.m */; };
 		B576D71111C7F34D0059B815 /* SynchronousViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B606A0F765A930064029C /* SynchronousViewController.m */; };
 		B576D71211C7F34D0059B815 /* iPhoneSampleAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B606B0F765A930064029C /* iPhoneSampleAppDelegate.m */; };
 		B576D71311C7F34D0059B815 /* UploadViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B606C0F765A930064029C /* UploadViewController.m */; };
 		B576D71411C7F34D0059B815 /* AuthenticationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B51791A21024C3E800583567 /* AuthenticationViewController.m */; };
-		B576D71511C7F34D0059B815 /* ASIInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = B522DACD1030B2AB009A2D22 /* ASIInputStream.m */; };
-		B576D71611C7F34D0059B815 /* ASIAuthenticationDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = B59A87C1103EC6F200300252 /* ASIAuthenticationDialog.m */; };
 		B576D71D11C7F34D0059B815 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D52C11C7CEFA0059B815 /* Foundation.framework */; };
 		B576D76611C7F4D90059B815 /* iPhoneMainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = B576D76511C7F4D90059B815 /* iPhoneMainWindow.xib */; };
 		B57AF5921258B3F1002A1F0C /* WebPageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B57AF5911258B3F1002A1F0C /* WebPageViewController.m */; };
 		B57AF5931258B3F1002A1F0C /* WebPageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B57AF5911258B3F1002A1F0C /* WebPageViewController.m */; };
 		B57AF5961258B401002A1F0C /* RequestProgressCell.m in Sources */ = {isa = PBXBuildFile; fileRef = B57AF5951258B401002A1F0C /* RequestProgressCell.m */; };
 		B57AF5971258B401002A1F0C /* RequestProgressCell.m in Sources */ = {isa = PBXBuildFile; fileRef = B57AF5951258B401002A1F0C /* RequestProgressCell.m */; };
-		B57D0F4812AA7D3600E5F992 /* ASIWebPageRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B57D0F4712AA7D3600E5F992 /* ASIWebPageRequest.m */; };
-		B57D0F4912AA7D3600E5F992 /* ASIWebPageRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B57D0F4712AA7D3600E5F992 /* ASIWebPageRequest.m */; };
-		B57D0F4A12AA7D3600E5F992 /* ASIWebPageRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B57D0F4712AA7D3600E5F992 /* ASIWebPageRequest.m */; };
 		B581DDCA12FDFEEE003BA9D0 /* GHUnitIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B581DDC912FDFEEE003BA9D0 /* GHUnitIOS.framework */; };
-		B5873FD610FF28CA001E145F /* ASIS3BucketObject.m in Sources */ = {isa = PBXBuildFile; fileRef = B5873FC210FF28CA001E145F /* ASIS3BucketObject.m */; };
-		B5873FD810FF28CA001E145F /* ASIS3Request.m in Sources */ = {isa = PBXBuildFile; fileRef = B5873FC610FF28CA001E145F /* ASIS3Request.m */; };
-		B5873FD910FF28CA001E145F /* ASICloudFilesCDNRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B5873FC910FF28CA001E145F /* ASICloudFilesCDNRequest.m */; };
-		B5873FDA10FF28CA001E145F /* ASICloudFilesContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = B5873FCB10FF28CA001E145F /* ASICloudFilesContainer.m */; };
-		B5873FDB10FF28CA001E145F /* ASICloudFilesContainerRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B5873FCD10FF28CA001E145F /* ASICloudFilesContainerRequest.m */; };
-		B5873FDC10FF28CA001E145F /* ASICloudFilesContainerXMLParserDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B5873FCF10FF28CA001E145F /* ASICloudFilesContainerXMLParserDelegate.m */; };
-		B5873FDD10FF28CA001E145F /* ASICloudFilesObject.m in Sources */ = {isa = PBXBuildFile; fileRef = B5873FD110FF28CA001E145F /* ASICloudFilesObject.m */; };
-		B5873FDE10FF28CA001E145F /* ASICloudFilesObjectRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B5873FD310FF28CA001E145F /* ASICloudFilesObjectRequest.m */; };
-		B5873FDF10FF28CA001E145F /* ASICloudFilesRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B5873FD510FF28CA001E145F /* ASICloudFilesRequest.m */; };
-		B5873FF510FF2904001E145F /* ASICloudFilesRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B5873FF310FF2904001E145F /* ASICloudFilesRequestTests.m */; };
-		B59A87C2103EC6F200300252 /* ASIAuthenticationDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = B59A87C1103EC6F200300252 /* ASIAuthenticationDialog.m */; };
-		B59A87C3103EC6F200300252 /* ASIAuthenticationDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = B59A87C1103EC6F200300252 /* ASIAuthenticationDialog.m */; };
 		B5BD2AFA11CA541100D7C426 /* iPadSampleAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B5BD2AF911CA541100D7C426 /* iPadSampleAppDelegate.m */; };
 		B5BD2B0111CA542000D7C426 /* DetailCell.m in Sources */ = {isa = PBXBuildFile; fileRef = B5BD2AFC11CA542000D7C426 /* DetailCell.m */; };
 		B5BD2B0211CA542000D7C426 /* InfoCell.m in Sources */ = {isa = PBXBuildFile; fileRef = B5BD2AFE11CA542000D7C426 /* InfoCell.m */; };
@@ -105,11 +71,6 @@
 		B5BD2B0C11CA542700D7C426 /* SampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5BD2B0A11CA542700D7C426 /* SampleViewController.m */; };
 		B5BD2B0E11CA542700D7C426 /* SampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5BD2B0A11CA542700D7C426 /* SampleViewController.m */; };
 		B5BF64EF12FDFC7100CBC324 /* GHUnitIOSTestMain.m in Sources */ = {isa = PBXBuildFile; fileRef = B5BF64EE12FDFC7100CBC324 /* GHUnitIOSTestMain.m */; };
-		B5C6663E100A82D7004F3C96 /* ASIS3RequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B5C6663D100A82D7004F3C96 /* ASIS3RequestTests.m */; };
-		B5EA45AA109B56D800E920CB /* StressTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B5EA45A9109B56D800E920CB /* StressTests.m */; };
-		B5FE752711DBBA6400F898C8 /* ASIDownloadCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FE752511DBBA6400F898C8 /* ASIDownloadCache.m */; };
-		B5FE752811DBBA6400F898C8 /* ASIDownloadCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FE752511DBBA6400F898C8 /* ASIDownloadCache.m */; };
-		B5FE752911DBBA6400F898C8 /* ASIDownloadCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FE752511DBBA6400F898C8 /* ASIDownloadCache.m */; };
 		DADCEB8512D5039F00958557 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D4C011C7CC970059B815 /* CFNetwork.framework */; };
 		DADCEB8612D503AD00958557 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D4C011C7CC970059B815 /* CFNetwork.framework */; };
 		DADCEB8A12D503F500958557 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D4D011C7CCBC0059B815 /* CoreGraphics.framework */; };
@@ -143,54 +104,47 @@
 
 /* Begin PBXFileReference section */
 		1D6058910D05DD3D006BFB54 /* ASIHTTPRequest iPhone.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ASIHTTPRequest iPhone.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		B50C1821121C26DB0055FCAB /* ClientCertificateTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ClientCertificateTests.h; sourceTree = "<group>"; };
-		B50C1822121C26DB0055FCAB /* ClientCertificateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ClientCertificateTests.m; sourceTree = "<group>"; };
+		8C7B4230134D239A00CAD6D3 /* libasihttp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libasihttp.a; sourceTree = SOURCE_ROOT; };
+		8C7B4235134D2AD200CAD6D3 /* ASICloudFilesRequestTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesRequestTests.h; sourceTree = "<group>"; };
+		8C7B4236134D2AD200CAD6D3 /* ASICloudFilesRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesRequestTests.m; sourceTree = "<group>"; };
+		8C7B4237134D2AD200CAD6D3 /* ASIDataCompressorTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIDataCompressorTests.h; sourceTree = "<group>"; };
+		8C7B4238134D2AD200CAD6D3 /* ASIDataCompressorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIDataCompressorTests.m; sourceTree = "<group>"; };
+		8C7B4239134D2AD200CAD6D3 /* ASIDownloadCacheTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIDownloadCacheTests.h; sourceTree = "<group>"; };
+		8C7B423A134D2AD200CAD6D3 /* ASIDownloadCacheTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIDownloadCacheTests.m; sourceTree = "<group>"; };
+		8C7B423B134D2AD200CAD6D3 /* ASIFormDataRequestTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIFormDataRequestTests.h; sourceTree = "<group>"; };
+		8C7B423C134D2AD200CAD6D3 /* ASIFormDataRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIFormDataRequestTests.m; sourceTree = "<group>"; };
+		8C7B423D134D2AD200CAD6D3 /* ASIHTTPRequestTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIHTTPRequestTests.h; sourceTree = "<group>"; };
+		8C7B423E134D2AD200CAD6D3 /* ASIHTTPRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIHTTPRequestTests.m; sourceTree = "<group>"; };
+		8C7B423F134D2AD200CAD6D3 /* ASINetworkQueueTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASINetworkQueueTests.h; sourceTree = "<group>"; };
+		8C7B4240134D2AD200CAD6D3 /* ASINetworkQueueTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASINetworkQueueTests.m; sourceTree = "<group>"; };
+		8C7B4241134D2AD200CAD6D3 /* ASIS3RequestTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIS3RequestTests.h; sourceTree = "<group>"; };
+		8C7B4242134D2AD200CAD6D3 /* ASIS3RequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIS3RequestTests.m; sourceTree = "<group>"; };
+		8C7B4243134D2AD200CAD6D3 /* ASITestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASITestCase.h; sourceTree = "<group>"; };
+		8C7B4244134D2AD200CAD6D3 /* ASITestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASITestCase.m; sourceTree = "<group>"; };
+		8C7B4245134D2AD200CAD6D3 /* ASIWebPageRequestTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIWebPageRequestTests.h; sourceTree = "<group>"; };
+		8C7B4246134D2AD200CAD6D3 /* ASIWebPageRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIWebPageRequestTests.m; sourceTree = "<group>"; };
+		8C7B4247134D2AD200CAD6D3 /* BlocksTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlocksTests.h; sourceTree = "<group>"; };
+		8C7B4248134D2AD200CAD6D3 /* BlocksTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlocksTests.m; sourceTree = "<group>"; };
+		8C7B4249134D2AD200CAD6D3 /* ClientCertificateTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ClientCertificateTests.h; sourceTree = "<group>"; };
+		8C7B424A134D2AD200CAD6D3 /* ClientCertificateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ClientCertificateTests.m; sourceTree = "<group>"; };
+		8C7B424C134D2AD200CAD6D3 /* PerformanceTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PerformanceTests.h; sourceTree = "<group>"; };
+		8C7B424D134D2AD200CAD6D3 /* PerformanceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PerformanceTests.m; sourceTree = "<group>"; };
+		8C7B424E134D2AD200CAD6D3 /* ProxyTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProxyTests.h; sourceTree = "<group>"; };
+		8C7B424F134D2AD200CAD6D3 /* ProxyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ProxyTests.m; sourceTree = "<group>"; };
+		8C7B4250134D2AD200CAD6D3 /* StressTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StressTests.h; sourceTree = "<group>"; };
+		8C7B4251134D2AD200CAD6D3 /* StressTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StressTests.m; sourceTree = "<group>"; };
+		8C7B4264134D2C0000CAD6D3 /* GHUnitIOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = GHUnitIOS.framework; sourceTree = "<group>"; };
+		8C7B4265134D2C0000CAD6D3 /* GHUnitIOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = GHUnitIOS.framework; sourceTree = "<group>"; };
+		8C7B4266134D2C0000CAD6D3 /* README-GHUnit */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "README-GHUnit"; sourceTree = "<group>"; };
 		B50C182B121C26FA0055FCAB /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		B50C1847121C27510055FCAB /* client.p12 */ = {isa = PBXFileReference; lastKnownFileType = file; name = client.p12; path = "iPhone Sample/Resources/client.p12"; sourceTree = "<group>"; };
-		B50D532A126C87ED0022EA6F /* BlocksTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlocksTests.h; sourceTree = "<group>"; };
-		B50D532B126C87ED0022EA6F /* BlocksTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlocksTests.m; sourceTree = "<group>"; };
 		B50F66181297FA45003887B1 /* strict.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = strict.xcconfig; sourceTree = "<group>"; };
 		B51791A11024C3E800583567 /* AuthenticationViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AuthenticationViewController.h; path = "iPhone Sample/AuthenticationViewController.h"; sourceTree = "<group>"; };
 		B51791A21024C3E800583567 /* AuthenticationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AuthenticationViewController.m; path = "iPhone Sample/AuthenticationViewController.m"; sourceTree = "<group>"; };
-		B51A1A7911DDF7BF00ED75CF /* ASIDownloadCacheTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIDownloadCacheTests.h; sourceTree = "<group>"; };
-		B51A1A7A11DDF7BF00ED75CF /* ASIDownloadCacheTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIDownloadCacheTests.m; sourceTree = "<group>"; };
-		B522DACC1030B2AB009A2D22 /* ASIInputStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIInputStream.h; sourceTree = "<group>"; };
-		B522DACD1030B2AB009A2D22 /* ASIInputStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIInputStream.m; sourceTree = "<group>"; };
 		B523254111CA01F1006C6E5A /* Sample.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Sample.xib; path = "iPhone Sample/Resources/Sample.xib"; sourceTree = "<group>"; };
 		B52325AC11CA05A8006C6E5A /* info.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = info.png; path = "iPhone Sample/Resources/info.png"; sourceTree = "<group>"; };
-		B5254FF71025F9BF00CF7BC4 /* ProxyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ProxyTests.m; sourceTree = "<group>"; };
-		B5254FF81025F9BF00CF7BC4 /* ProxyTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProxyTests.h; sourceTree = "<group>"; };
-		B52D4A2D10DA4ED5008E8365 /* PerformanceTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PerformanceTests.h; sourceTree = "<group>"; };
-		B52D4A2E10DA4ED5008E8365 /* PerformanceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PerformanceTests.m; sourceTree = "<group>"; };
-		B53E6D911257B45800C1E79A /* ASIDataDecompressor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIDataDecompressor.m; sourceTree = "<group>"; };
-		B53E6D921257B45800C1E79A /* ASIDataDecompressor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIDataDecompressor.h; sourceTree = "<group>"; };
-		B53E6D931257B45800C1E79A /* ASIDataCompressor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIDataCompressor.m; sourceTree = "<group>"; };
-		B53E6D941257B45800C1E79A /* ASIDataCompressor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIDataCompressor.h; sourceTree = "<group>"; };
-		B5403FFF115114BA00D8BE63 /* ASIS3Bucket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIS3Bucket.h; sourceTree = "<group>"; };
-		B5404000115114BA00D8BE63 /* ASIS3Bucket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIS3Bucket.m; sourceTree = "<group>"; };
-		B5404001115114BA00D8BE63 /* ASIS3BucketRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIS3BucketRequest.h; sourceTree = "<group>"; };
-		B5404002115114BA00D8BE63 /* ASIS3BucketRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIS3BucketRequest.m; sourceTree = "<group>"; };
-		B5404003115114BA00D8BE63 /* ASIS3ObjectRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIS3ObjectRequest.h; sourceTree = "<group>"; };
-		B5404004115114BA00D8BE63 /* ASIS3ObjectRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIS3ObjectRequest.m; sourceTree = "<group>"; };
-		B5404005115114BA00D8BE63 /* ASIS3ServiceRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIS3ServiceRequest.h; sourceTree = "<group>"; };
-		B5404006115114BA00D8BE63 /* ASIS3ServiceRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIS3ServiceRequest.m; sourceTree = "<group>"; };
-		B551DB4610D6938500EC1CBF /* ASIHTTPRequestConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIHTTPRequestConfig.h; sourceTree = "<group>"; };
-		B55252B211D22E2200F9B170 /* Reachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Reachability.h; sourceTree = "<group>"; };
-		B55252B311D22E2200F9B170 /* Reachability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Reachability.m; sourceTree = "<group>"; };
 		B558B58911C7F637009B4627 /* iPhoneInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = iPhoneInfo.plist; path = "iPhone Sample/iPhoneInfo.plist"; sourceTree = "<group>"; };
 		B558B58B11C7F63E009B4627 /* iPadInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = iPadInfo.plist; path = "iPhone Sample/iPadInfo.plist"; sourceTree = "<group>"; };
-		B55B60450F765A320064029C /* ASIFormDataRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIFormDataRequest.h; sourceTree = "<group>"; };
-		B55B60460F765A320064029C /* ASIFormDataRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIFormDataRequest.m; sourceTree = "<group>"; };
-		B55B60470F765A320064029C /* ASIHTTPRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIHTTPRequest.h; sourceTree = "<group>"; };
-		B55B60480F765A320064029C /* ASIHTTPRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIHTTPRequest.m; sourceTree = "<group>"; };
-		B55B60490F765A320064029C /* ASINetworkQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASINetworkQueue.h; sourceTree = "<group>"; };
-		B55B604A0F765A320064029C /* ASINetworkQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASINetworkQueue.m; sourceTree = "<group>"; };
-		B55B60520F765A3C0064029C /* ASIFormDataRequestTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIFormDataRequestTests.h; sourceTree = "<group>"; };
-		B55B60530F765A3C0064029C /* ASIFormDataRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIFormDataRequestTests.m; sourceTree = "<group>"; };
-		B55B60540F765A3C0064029C /* ASIHTTPRequestTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIHTTPRequestTests.h; sourceTree = "<group>"; };
-		B55B60550F765A3C0064029C /* ASIHTTPRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIHTTPRequestTests.m; sourceTree = "<group>"; };
-		B55B60560F765A3C0064029C /* ASINetworkQueueTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASINetworkQueueTests.h; sourceTree = "<group>"; };
-		B55B60570F765A3C0064029C /* ASINetworkQueueTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASINetworkQueueTests.m; sourceTree = "<group>"; };
 		B55B605F0F765A750064029C /* iPhone_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = iPhone_Prefix.pch; path = "iPhone Sample/iPhone_Prefix.pch"; sourceTree = "<group>"; };
 		B55B60600F765A750064029C /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "iPhone Sample/main.m"; sourceTree = "<group>"; };
 		B55B60670F765A930064029C /* QueueViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = QueueViewController.m; path = "iPhone Sample/QueueViewController.m"; sourceTree = "<group>"; };
@@ -204,11 +158,7 @@
 		B55B60730F765A990064029C /* iphone-icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "iphone-icon.png"; path = "iPhone Sample/iphone-icon.png"; sourceTree = "<group>"; };
 		B55B60C70F765BB00064029C /* Tests.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tests.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B55B60CB0F765BB10064029C /* Tests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Tests-Info.plist"; path = "iPhone Sample/Tests-Info.plist"; sourceTree = "<group>"; };
-		B565291E101C8BD7000499CF /* ASITestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASITestCase.h; sourceTree = "<group>"; };
-		B565291F101C8BD7000499CF /* ASITestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASITestCase.m; sourceTree = "<group>"; };
 		B56529A2101C8EDA000499CF /* iphone-tests-icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "iphone-tests-icon.png"; path = "iPhone Sample/iphone-tests-icon.png"; sourceTree = "<group>"; };
-		B5747F271174BB8300C9414E /* ASIHTTPRequestDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIHTTPRequestDelegate.h; sourceTree = "<group>"; };
-		B5747F281174BB8300C9414E /* ASIProgressDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIProgressDelegate.h; sourceTree = "<group>"; };
 		B576D4C011C7CC970059B815 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		B576D4C311C7CC9C0059B815 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		B576D4C611C7CC9F0059B815 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
@@ -222,31 +172,7 @@
 		B57AF5911258B3F1002A1F0C /* WebPageViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WebPageViewController.m; path = "iPhone Sample/WebPageViewController.m"; sourceTree = "<group>"; };
 		B57AF5941258B401002A1F0C /* RequestProgressCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RequestProgressCell.h; path = "iPhone Sample/RequestProgressCell.h"; sourceTree = "<group>"; };
 		B57AF5951258B401002A1F0C /* RequestProgressCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RequestProgressCell.m; path = "iPhone Sample/RequestProgressCell.m"; sourceTree = "<group>"; };
-		B57D0F4612AA7D3600E5F992 /* ASIWebPageRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASIWebPageRequest.h; path = ASIWebPageRequest/ASIWebPageRequest.h; sourceTree = "<group>"; };
-		B57D0F4712AA7D3600E5F992 /* ASIWebPageRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASIWebPageRequest.m; path = ASIWebPageRequest/ASIWebPageRequest.m; sourceTree = "<group>"; };
 		B581DDC912FDFEEE003BA9D0 /* GHUnitIOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GHUnitIOS.framework; path = External/GHUnit/GHUnitIOS.framework; sourceTree = "<group>"; };
-		B5873FC110FF28CA001E145F /* ASIS3BucketObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIS3BucketObject.h; sourceTree = "<group>"; };
-		B5873FC210FF28CA001E145F /* ASIS3BucketObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIS3BucketObject.m; sourceTree = "<group>"; };
-		B5873FC510FF28CA001E145F /* ASIS3Request.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIS3Request.h; sourceTree = "<group>"; };
-		B5873FC610FF28CA001E145F /* ASIS3Request.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIS3Request.m; sourceTree = "<group>"; };
-		B5873FC810FF28CA001E145F /* ASICloudFilesCDNRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesCDNRequest.h; sourceTree = "<group>"; };
-		B5873FC910FF28CA001E145F /* ASICloudFilesCDNRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesCDNRequest.m; sourceTree = "<group>"; };
-		B5873FCA10FF28CA001E145F /* ASICloudFilesContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesContainer.h; sourceTree = "<group>"; };
-		B5873FCB10FF28CA001E145F /* ASICloudFilesContainer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesContainer.m; sourceTree = "<group>"; };
-		B5873FCC10FF28CA001E145F /* ASICloudFilesContainerRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesContainerRequest.h; sourceTree = "<group>"; };
-		B5873FCD10FF28CA001E145F /* ASICloudFilesContainerRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesContainerRequest.m; sourceTree = "<group>"; };
-		B5873FCE10FF28CA001E145F /* ASICloudFilesContainerXMLParserDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesContainerXMLParserDelegate.h; sourceTree = "<group>"; };
-		B5873FCF10FF28CA001E145F /* ASICloudFilesContainerXMLParserDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesContainerXMLParserDelegate.m; sourceTree = "<group>"; };
-		B5873FD010FF28CA001E145F /* ASICloudFilesObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesObject.h; sourceTree = "<group>"; };
-		B5873FD110FF28CA001E145F /* ASICloudFilesObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesObject.m; sourceTree = "<group>"; };
-		B5873FD210FF28CA001E145F /* ASICloudFilesObjectRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesObjectRequest.h; sourceTree = "<group>"; };
-		B5873FD310FF28CA001E145F /* ASICloudFilesObjectRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesObjectRequest.m; sourceTree = "<group>"; };
-		B5873FD410FF28CA001E145F /* ASICloudFilesRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesRequest.h; sourceTree = "<group>"; };
-		B5873FD510FF28CA001E145F /* ASICloudFilesRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesRequest.m; sourceTree = "<group>"; };
-		B5873FF310FF2904001E145F /* ASICloudFilesRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesRequestTests.m; sourceTree = "<group>"; };
-		B5873FF410FF2904001E145F /* ASICloudFilesRequestTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesRequestTests.h; sourceTree = "<group>"; };
-		B59A87C0103EC6F200300252 /* ASIAuthenticationDialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIAuthenticationDialog.h; sourceTree = "<group>"; };
-		B59A87C1103EC6F200300252 /* ASIAuthenticationDialog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIAuthenticationDialog.m; sourceTree = "<group>"; };
 		B5BD2AF811CA541100D7C426 /* iPadSampleAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = iPadSampleAppDelegate.h; path = "iPhone Sample/iPadSampleAppDelegate.h"; sourceTree = "<group>"; };
 		B5BD2AF911CA541100D7C426 /* iPadSampleAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = iPadSampleAppDelegate.m; path = "iPhone Sample/iPadSampleAppDelegate.m"; sourceTree = "<group>"; };
 		B5BD2AFB11CA542000D7C426 /* DetailCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DetailCell.h; path = "iPhone Sample/DetailCell.h"; sourceTree = "<group>"; };
@@ -260,13 +186,6 @@
 		B5BD2B0911CA542700D7C426 /* SampleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SampleViewController.h; path = "iPhone Sample/SampleViewController.h"; sourceTree = "<group>"; };
 		B5BD2B0A11CA542700D7C426 /* SampleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SampleViewController.m; path = "iPhone Sample/SampleViewController.m"; sourceTree = "<group>"; };
 		B5BF64EE12FDFC7100CBC324 /* GHUnitIOSTestMain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GHUnitIOSTestMain.m; path = "iPhone Sample/GHUnitIOSTestMain.m"; sourceTree = "<group>"; };
-		B5C6663C100A82D7004F3C96 /* ASIS3RequestTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIS3RequestTests.h; sourceTree = "<group>"; };
-		B5C6663D100A82D7004F3C96 /* ASIS3RequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIS3RequestTests.m; sourceTree = "<group>"; };
-		B5EA45A8109B56D800E920CB /* StressTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StressTests.h; sourceTree = "<group>"; };
-		B5EA45A9109B56D800E920CB /* StressTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StressTests.m; sourceTree = "<group>"; };
-		B5FE752511DBBA6400F898C8 /* ASIDownloadCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIDownloadCache.m; sourceTree = "<group>"; };
-		B5FE752611DBBA6400F898C8 /* ASIDownloadCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIDownloadCache.h; sourceTree = "<group>"; };
-		B5FE752A11DBBA6A00F898C8 /* ASICacheDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICacheDelegate.h; sourceTree = "<group>"; };
 		DADCEB9812D5057700958557 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = /usr/lib/libxml2.dylib; sourceTree = "<absolute>"; };
 		DADCEB9E12D505AB00958557 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = /usr/lib/libz.dylib; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
@@ -284,6 +203,7 @@
 				DADCEB9012D5050600958557 /* UIKit.framework in Frameworks */,
 				DADCEB9912D5057700958557 /* libxml2.dylib in Frameworks */,
 				DADCEB9F12D505AB00958557 /* libz.dylib in Frameworks */,
+				8C7B4232134D23A600CAD6D3 /* libasihttp.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -291,6 +211,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B581DDCA12FDFEEE003BA9D0 /* GHUnitIOS.framework in Frameworks */,
+				8C7B4231134D239A00CAD6D3 /* libasihttp.a in Frameworks */,
 				B576D4C111C7CC970059B815 /* CFNetwork.framework in Frameworks */,
 				B576D4D111C7CCBC0059B815 /* CoreGraphics.framework in Frameworks */,
 				DADCEB8C12D5046A00958557 /* Foundation.framework in Frameworks */,
@@ -300,7 +222,6 @@
 				B576D4C411C7CC9C0059B815 /* UIKit.framework in Frameworks */,
 				DADCEB9A12D5058500958557 /* libxml2.dylib in Frameworks */,
 				DADCEBA012D505B900958557 /* libz.dylib in Frameworks */,
-				B581DDCA12FDFEEE003BA9D0 /* GHUnitIOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -316,43 +237,13 @@
 				DADCEB9212D5051200958557 /* UIKit.framework in Frameworks */,
 				DADCEB9B12D5058C00958557 /* libxml2.dylib in Frameworks */,
 				DADCEBA112D505C700958557 /* libz.dylib in Frameworks */,
+				8C7B4233134D23A700CAD6D3 /* libasihttp.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		080E96DDFE201D6D7F000001 /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				B551DB4610D6938500EC1CBF /* ASIHTTPRequestConfig.h */,
-				B5FE752A11DBBA6A00F898C8 /* ASICacheDelegate.h */,
-				B5747F271174BB8300C9414E /* ASIHTTPRequestDelegate.h */,
-				B5747F281174BB8300C9414E /* ASIProgressDelegate.h */,
-				B59A87C0103EC6F200300252 /* ASIAuthenticationDialog.h */,
-				B59A87C1103EC6F200300252 /* ASIAuthenticationDialog.m */,
-				B522DACC1030B2AB009A2D22 /* ASIInputStream.h */,
-				B522DACD1030B2AB009A2D22 /* ASIInputStream.m */,
-				B55B60450F765A320064029C /* ASIFormDataRequest.h */,
-				B55B60460F765A320064029C /* ASIFormDataRequest.m */,
-				B55B60470F765A320064029C /* ASIHTTPRequest.h */,
-				B55B60480F765A320064029C /* ASIHTTPRequest.m */,
-				B55B60490F765A320064029C /* ASINetworkQueue.h */,
-				B55B604A0F765A320064029C /* ASINetworkQueue.m */,
-				B5FE752611DBBA6400F898C8 /* ASIDownloadCache.h */,
-				B5FE752511DBBA6400F898C8 /* ASIDownloadCache.m */,
-				B53E6D921257B45800C1E79A /* ASIDataDecompressor.h */,
-				B53E6D911257B45800C1E79A /* ASIDataDecompressor.m */,
-				B53E6D941257B45800C1E79A /* ASIDataCompressor.h */,
-				B53E6D931257B45800C1E79A /* ASIDataCompressor.m */,
-				B57D0F4412AA7D2300E5F992 /* ASIWebPageRequest */,
-				B5873FC010FF28CA001E145F /* S3 */,
-				B5873FC710FF28CA001E145F /* CloudFiles */,
-				B55B60510F765A3C0064029C /* Tests */,
-			);
-			path = Classes;
-			sourceTree = "<group>";
-		};
 		19C28FACFE9D520D11CA2CBB /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -366,8 +257,9 @@
 		29B97314FDCFA39411CA2CEA /* iPhone */ = {
 			isa = PBXGroup;
 			children = (
-				B5D1454E1029E20D004379B8 /* External */,
-				080E96DDFE201D6D7F000001 /* Classes */,
+				8C7B4261134D2C0000CAD6D3 /* External */,
+				8C7B4234134D2AD200CAD6D3 /* Tests */,
+				8C7B4230134D239A00CAD6D3 /* libasihttp.a */,
 				29B97315FDCFA39411CA2CEA /* Other Sources */,
 				29B97317FDCFA39411CA2CEA /* Resources */,
 				29B97323FDCFA39411CA2CEA /* Frameworks */,
@@ -436,6 +328,68 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		8C7B4234134D2AD200CAD6D3 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				8C7B4235134D2AD200CAD6D3 /* ASICloudFilesRequestTests.h */,
+				8C7B4236134D2AD200CAD6D3 /* ASICloudFilesRequestTests.m */,
+				8C7B4237134D2AD200CAD6D3 /* ASIDataCompressorTests.h */,
+				8C7B4238134D2AD200CAD6D3 /* ASIDataCompressorTests.m */,
+				8C7B4239134D2AD200CAD6D3 /* ASIDownloadCacheTests.h */,
+				8C7B423A134D2AD200CAD6D3 /* ASIDownloadCacheTests.m */,
+				8C7B423B134D2AD200CAD6D3 /* ASIFormDataRequestTests.h */,
+				8C7B423C134D2AD200CAD6D3 /* ASIFormDataRequestTests.m */,
+				8C7B423D134D2AD200CAD6D3 /* ASIHTTPRequestTests.h */,
+				8C7B423E134D2AD200CAD6D3 /* ASIHTTPRequestTests.m */,
+				8C7B423F134D2AD200CAD6D3 /* ASINetworkQueueTests.h */,
+				8C7B4240134D2AD200CAD6D3 /* ASINetworkQueueTests.m */,
+				8C7B4241134D2AD200CAD6D3 /* ASIS3RequestTests.h */,
+				8C7B4242134D2AD200CAD6D3 /* ASIS3RequestTests.m */,
+				8C7B4243134D2AD200CAD6D3 /* ASITestCase.h */,
+				8C7B4244134D2AD200CAD6D3 /* ASITestCase.m */,
+				8C7B4245134D2AD200CAD6D3 /* ASIWebPageRequestTests.h */,
+				8C7B4246134D2AD200CAD6D3 /* ASIWebPageRequestTests.m */,
+				8C7B4247134D2AD200CAD6D3 /* BlocksTests.h */,
+				8C7B4248134D2AD200CAD6D3 /* BlocksTests.m */,
+				8C7B4249134D2AD200CAD6D3 /* ClientCertificateTests.h */,
+				8C7B424A134D2AD200CAD6D3 /* ClientCertificateTests.m */,
+				8C7B424C134D2AD200CAD6D3 /* PerformanceTests.h */,
+				8C7B424D134D2AD200CAD6D3 /* PerformanceTests.m */,
+				8C7B424E134D2AD200CAD6D3 /* ProxyTests.h */,
+				8C7B424F134D2AD200CAD6D3 /* ProxyTests.m */,
+				8C7B4250134D2AD200CAD6D3 /* StressTests.h */,
+				8C7B4251134D2AD200CAD6D3 /* StressTests.m */,
+			);
+			name = Tests;
+			path = Classes/Tests;
+			sourceTree = "<group>";
+		};
+		8C7B4261134D2C0000CAD6D3 /* External */ = {
+			isa = PBXGroup;
+			children = (
+				8C7B4262134D2C0000CAD6D3 /* GHUnit */,
+			);
+			path = External;
+			sourceTree = "<group>";
+		};
+		8C7B4262134D2C0000CAD6D3 /* GHUnit */ = {
+			isa = PBXGroup;
+			children = (
+				8C7B4263134D2C0000CAD6D3 /* __MACOSX */,
+				8C7B4265134D2C0000CAD6D3 /* GHUnitIOS.framework */,
+				8C7B4266134D2C0000CAD6D3 /* README-GHUnit */,
+			);
+			path = GHUnit;
+			sourceTree = "<group>";
+		};
+		8C7B4263134D2C0000CAD6D3 /* __MACOSX */ = {
+			isa = PBXGroup;
+			children = (
+				8C7B4264134D2C0000CAD6D3 /* GHUnitIOS.framework */,
+			);
+			path = __MACOSX;
+			sourceTree = "<group>";
+		};
 		B52329A911CA3380006C6E5A /* UI helpers */ = {
 			isa = PBXGroup;
 			children = (
@@ -453,103 +407,6 @@
 				B5BD2B0A11CA542700D7C426 /* SampleViewController.m */,
 			);
 			name = "UI helpers";
-			sourceTree = "<group>";
-		};
-		B55252B111D22E2200F9B170 /* Reachability */ = {
-			isa = PBXGroup;
-			children = (
-				B55252B211D22E2200F9B170 /* Reachability.h */,
-				B55252B311D22E2200F9B170 /* Reachability.m */,
-			);
-			path = Reachability;
-			sourceTree = "<group>";
-		};
-		B55B60510F765A3C0064029C /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				B565291E101C8BD7000499CF /* ASITestCase.h */,
-				B565291F101C8BD7000499CF /* ASITestCase.m */,
-				B55B60520F765A3C0064029C /* ASIFormDataRequestTests.h */,
-				B55B60530F765A3C0064029C /* ASIFormDataRequestTests.m */,
-				B55B60540F765A3C0064029C /* ASIHTTPRequestTests.h */,
-				B55B60550F765A3C0064029C /* ASIHTTPRequestTests.m */,
-				B55B60560F765A3C0064029C /* ASINetworkQueueTests.h */,
-				B55B60570F765A3C0064029C /* ASINetworkQueueTests.m */,
-				B5C6663C100A82D7004F3C96 /* ASIS3RequestTests.h */,
-				B5C6663D100A82D7004F3C96 /* ASIS3RequestTests.m */,
-				B5873FF410FF2904001E145F /* ASICloudFilesRequestTests.h */,
-				B5873FF310FF2904001E145F /* ASICloudFilesRequestTests.m */,
-				B51A1A7911DDF7BF00ED75CF /* ASIDownloadCacheTests.h */,
-				B51A1A7A11DDF7BF00ED75CF /* ASIDownloadCacheTests.m */,
-				B5EA45A8109B56D800E920CB /* StressTests.h */,
-				B5EA45A9109B56D800E920CB /* StressTests.m */,
-				B5254FF81025F9BF00CF7BC4 /* ProxyTests.h */,
-				B5254FF71025F9BF00CF7BC4 /* ProxyTests.m */,
-				B52D4A2D10DA4ED5008E8365 /* PerformanceTests.h */,
-				B52D4A2E10DA4ED5008E8365 /* PerformanceTests.m */,
-				B50C1821121C26DB0055FCAB /* ClientCertificateTests.h */,
-				B50C1822121C26DB0055FCAB /* ClientCertificateTests.m */,
-				B50D532A126C87ED0022EA6F /* BlocksTests.h */,
-				B50D532B126C87ED0022EA6F /* BlocksTests.m */,
-			);
-			path = Tests;
-			sourceTree = "<group>";
-		};
-		B57D0F4412AA7D2300E5F992 /* ASIWebPageRequest */ = {
-			isa = PBXGroup;
-			children = (
-				B57D0F4612AA7D3600E5F992 /* ASIWebPageRequest.h */,
-				B57D0F4712AA7D3600E5F992 /* ASIWebPageRequest.m */,
-			);
-			name = ASIWebPageRequest;
-			sourceTree = "<group>";
-		};
-		B5873FC010FF28CA001E145F /* S3 */ = {
-			isa = PBXGroup;
-			children = (
-				B5403FFF115114BA00D8BE63 /* ASIS3Bucket.h */,
-				B5404000115114BA00D8BE63 /* ASIS3Bucket.m */,
-				B5404001115114BA00D8BE63 /* ASIS3BucketRequest.h */,
-				B5404002115114BA00D8BE63 /* ASIS3BucketRequest.m */,
-				B5404003115114BA00D8BE63 /* ASIS3ObjectRequest.h */,
-				B5404004115114BA00D8BE63 /* ASIS3ObjectRequest.m */,
-				B5404005115114BA00D8BE63 /* ASIS3ServiceRequest.h */,
-				B5404006115114BA00D8BE63 /* ASIS3ServiceRequest.m */,
-				B5873FC110FF28CA001E145F /* ASIS3BucketObject.h */,
-				B5873FC210FF28CA001E145F /* ASIS3BucketObject.m */,
-				B5873FC510FF28CA001E145F /* ASIS3Request.h */,
-				B5873FC610FF28CA001E145F /* ASIS3Request.m */,
-			);
-			path = S3;
-			sourceTree = "<group>";
-		};
-		B5873FC710FF28CA001E145F /* CloudFiles */ = {
-			isa = PBXGroup;
-			children = (
-				B5873FC810FF28CA001E145F /* ASICloudFilesCDNRequest.h */,
-				B5873FC910FF28CA001E145F /* ASICloudFilesCDNRequest.m */,
-				B5873FCA10FF28CA001E145F /* ASICloudFilesContainer.h */,
-				B5873FCB10FF28CA001E145F /* ASICloudFilesContainer.m */,
-				B5873FCC10FF28CA001E145F /* ASICloudFilesContainerRequest.h */,
-				B5873FCD10FF28CA001E145F /* ASICloudFilesContainerRequest.m */,
-				B5873FCE10FF28CA001E145F /* ASICloudFilesContainerXMLParserDelegate.h */,
-				B5873FCF10FF28CA001E145F /* ASICloudFilesContainerXMLParserDelegate.m */,
-				B5873FD010FF28CA001E145F /* ASICloudFilesObject.h */,
-				B5873FD110FF28CA001E145F /* ASICloudFilesObject.m */,
-				B5873FD210FF28CA001E145F /* ASICloudFilesObjectRequest.h */,
-				B5873FD310FF28CA001E145F /* ASICloudFilesObjectRequest.m */,
-				B5873FD410FF28CA001E145F /* ASICloudFilesRequest.h */,
-				B5873FD510FF28CA001E145F /* ASICloudFilesRequest.m */,
-			);
-			path = CloudFiles;
-			sourceTree = "<group>";
-		};
-		B5D1454E1029E20D004379B8 /* External */ = {
-			isa = PBXGroup;
-			children = (
-				B55252B111D22E2200F9B170 /* Reachability */,
-			);
-			path = External;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -573,9 +430,9 @@
 			productReference = 1D6058910D05DD3D006BFB54 /* ASIHTTPRequest iPhone.app */;
 			productType = "com.apple.product-type.application";
 		};
-		B55B60C60F765BB00064029C /* Tests */ = {
+		B55B60C60F765BB00064029C /* iOS Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = B55B60CE0F765BB10064029C /* Build configuration list for PBXNativeTarget "Tests" */;
+			buildConfigurationList = B55B60CE0F765BB10064029C /* Build configuration list for PBXNativeTarget "iOS Tests" */;
 			buildPhases = (
 				B52D492410DA403A008E8365 /* ShellScript */,
 				B55B60C30F765BB00064029C /* Resources */,
@@ -587,7 +444,7 @@
 			);
 			dependencies = (
 			);
-			name = Tests;
+			name = "iOS Tests";
 			productName = Tests;
 			productReference = B55B60C70F765BB00064029C /* Tests.app */;
 			productType = "com.apple.product-type.application";
@@ -630,7 +487,7 @@
 			projectRoot = "";
 			targets = (
 				1D6058900D05DD3D006BFB54 /* iPhone */,
-				B55B60C60F765BB00064029C /* Tests */,
+				B55B60C60F765BB00064029C /* iOS Tests */,
 				B576D70211C7F34D0059B815 /* iPad */,
 			);
 		};
@@ -719,28 +576,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B55B604D0F765A320064029C /* ASIFormDataRequest.m in Sources */,
-				B55B604E0F765A320064029C /* ASIHTTPRequest.m in Sources */,
-				B55B604F0F765A320064029C /* ASINetworkQueue.m in Sources */,
 				B55B60620F765A750064029C /* main.m in Sources */,
 				B55B606F0F765A930064029C /* QueueViewController.m in Sources */,
 				B55B60700F765A930064029C /* SynchronousViewController.m in Sources */,
 				B55B60710F765A930064029C /* iPhoneSampleAppDelegate.m in Sources */,
 				B55B60720F765A930064029C /* UploadViewController.m in Sources */,
 				B51791A31024C3E800583567 /* AuthenticationViewController.m in Sources */,
-				B522DACF1030B2AB009A2D22 /* ASIInputStream.m in Sources */,
-				B59A87C3103EC6F200300252 /* ASIAuthenticationDialog.m in Sources */,
 				B5BD2B0411CA542000D7C426 /* DetailCell.m in Sources */,
 				B5BD2B0511CA542000D7C426 /* InfoCell.m in Sources */,
 				B5BD2B0611CA542000D7C426 /* ToggleCell.m in Sources */,
 				B5BD2B0E11CA542700D7C426 /* SampleViewController.m in Sources */,
-				B55252B511D22E2200F9B170 /* Reachability.m in Sources */,
-				B5FE752811DBBA6400F898C8 /* ASIDownloadCache.m in Sources */,
-				B53E6D971257B45800C1E79A /* ASIDataDecompressor.m in Sources */,
-				B53E6D981257B45800C1E79A /* ASIDataCompressor.m in Sources */,
 				B57AF5921258B3F1002A1F0C /* WebPageViewController.m in Sources */,
 				B57AF5961258B401002A1F0C /* RequestProgressCell.m in Sources */,
-				B57D0F4912AA7D3600E5F992 /* ASIWebPageRequest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -748,42 +595,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B55B60CF0F765BBA0064029C /* ASIFormDataRequest.m in Sources */,
-				B55B60D00F765BBD0064029C /* ASIHTTPRequest.m in Sources */,
-				B55B60D10F765BC00064029C /* ASINetworkQueue.m in Sources */,
-				B55B60D30F765BC90064029C /* ASIFormDataRequestTests.m in Sources */,
-				B55B60D40F765BCD0064029C /* ASIHTTPRequestTests.m in Sources */,
-				B55B60D50F765BD00064029C /* ASINetworkQueueTests.m in Sources */,
-				B5C6663E100A82D7004F3C96 /* ASIS3RequestTests.m in Sources */,
-				B5652920101C8BD7000499CF /* ASITestCase.m in Sources */,
-				B5254FF91025F9BF00CF7BC4 /* ProxyTests.m in Sources */,
-				B522DACE1030B2AB009A2D22 /* ASIInputStream.m in Sources */,
-				B59A87C2103EC6F200300252 /* ASIAuthenticationDialog.m in Sources */,
-				B5EA45AA109B56D800E920CB /* StressTests.m in Sources */,
-				B52D4A2F10DA4ED5008E8365 /* PerformanceTests.m in Sources */,
-				B5873FD610FF28CA001E145F /* ASIS3BucketObject.m in Sources */,
-				B5873FD810FF28CA001E145F /* ASIS3Request.m in Sources */,
-				B5873FD910FF28CA001E145F /* ASICloudFilesCDNRequest.m in Sources */,
-				B5873FDA10FF28CA001E145F /* ASICloudFilesContainer.m in Sources */,
-				B5873FDB10FF28CA001E145F /* ASICloudFilesContainerRequest.m in Sources */,
-				B5873FDC10FF28CA001E145F /* ASICloudFilesContainerXMLParserDelegate.m in Sources */,
-				B5873FDD10FF28CA001E145F /* ASICloudFilesObject.m in Sources */,
-				B5873FDE10FF28CA001E145F /* ASICloudFilesObjectRequest.m in Sources */,
-				B5873FDF10FF28CA001E145F /* ASICloudFilesRequest.m in Sources */,
-				B5873FF510FF2904001E145F /* ASICloudFilesRequestTests.m in Sources */,
-				B540400B115114BA00D8BE63 /* ASIS3Bucket.m in Sources */,
-				B540400C115114BA00D8BE63 /* ASIS3BucketRequest.m in Sources */,
-				B540400D115114BA00D8BE63 /* ASIS3ObjectRequest.m in Sources */,
-				B540400E115114BA00D8BE63 /* ASIS3ServiceRequest.m in Sources */,
-				B55252B411D22E2200F9B170 /* Reachability.m in Sources */,
-				B5FE752711DBBA6400F898C8 /* ASIDownloadCache.m in Sources */,
-				B51A1A9B11DDF85100ED75CF /* ASIDownloadCacheTests.m in Sources */,
-				B50C1823121C26DB0055FCAB /* ClientCertificateTests.m in Sources */,
-				B53E6D951257B45800C1E79A /* ASIDataDecompressor.m in Sources */,
-				B53E6D961257B45800C1E79A /* ASIDataCompressor.m in Sources */,
-				B50D532C126C87ED0022EA6F /* BlocksTests.m in Sources */,
-				B57D0F4A12AA7D3600E5F992 /* ASIWebPageRequest.m in Sources */,
 				B5BF64EF12FDFC7100CBC324 /* GHUnitIOSTestMain.m in Sources */,
+				8C7B4252134D2AD200CAD6D3 /* ASICloudFilesRequestTests.m in Sources */,
+				8C7B4254134D2AD200CAD6D3 /* ASIDownloadCacheTests.m in Sources */,
+				8C7B4255134D2AD200CAD6D3 /* ASIFormDataRequestTests.m in Sources */,
+				8C7B4256134D2AD200CAD6D3 /* ASIHTTPRequestTests.m in Sources */,
+				8C7B4257134D2AD200CAD6D3 /* ASINetworkQueueTests.m in Sources */,
+				8C7B4258134D2AD200CAD6D3 /* ASIS3RequestTests.m in Sources */,
+				8C7B4259134D2AD200CAD6D3 /* ASITestCase.m in Sources */,
+				8C7B425A134D2AD200CAD6D3 /* ASIWebPageRequestTests.m in Sources */,
+				8C7B425B134D2AD200CAD6D3 /* BlocksTests.m in Sources */,
+				8C7B425C134D2AD200CAD6D3 /* ClientCertificateTests.m in Sources */,
+				8C7B425E134D2AD200CAD6D3 /* PerformanceTests.m in Sources */,
+				8C7B425F134D2AD200CAD6D3 /* ProxyTests.m in Sources */,
+				8C7B4260134D2AD200CAD6D3 /* StressTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -791,30 +616,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B576D70B11C7F34D0059B815 /* ASIFormDataRequest.m in Sources */,
-				B576D70C11C7F34D0059B815 /* ASIHTTPRequest.m in Sources */,
-				B576D70D11C7F34D0059B815 /* ASINetworkQueue.m in Sources */,
 				B576D70F11C7F34D0059B815 /* main.m in Sources */,
 				B576D71011C7F34D0059B815 /* QueueViewController.m in Sources */,
 				B576D71111C7F34D0059B815 /* SynchronousViewController.m in Sources */,
 				B576D71211C7F34D0059B815 /* iPhoneSampleAppDelegate.m in Sources */,
 				B576D71311C7F34D0059B815 /* UploadViewController.m in Sources */,
 				B576D71411C7F34D0059B815 /* AuthenticationViewController.m in Sources */,
-				B576D71511C7F34D0059B815 /* ASIInputStream.m in Sources */,
-				B576D71611C7F34D0059B815 /* ASIAuthenticationDialog.m in Sources */,
 				B5BD2AFA11CA541100D7C426 /* iPadSampleAppDelegate.m in Sources */,
 				B5BD2B0111CA542000D7C426 /* DetailCell.m in Sources */,
 				B5BD2B0211CA542000D7C426 /* InfoCell.m in Sources */,
 				B5BD2B0311CA542000D7C426 /* ToggleCell.m in Sources */,
 				B5BD2B0B11CA542700D7C426 /* RootViewController.m in Sources */,
 				B5BD2B0C11CA542700D7C426 /* SampleViewController.m in Sources */,
-				B55252B611D22E2200F9B170 /* Reachability.m in Sources */,
-				B5FE752911DBBA6400F898C8 /* ASIDownloadCache.m in Sources */,
-				B53E6D991257B45800C1E79A /* ASIDataDecompressor.m in Sources */,
-				B53E6D9A1257B45800C1E79A /* ASIDataCompressor.m in Sources */,
 				B57AF5931258B3F1002A1F0C /* WebPageViewController.m in Sources */,
 				B57AF5971258B401002A1F0C /* RequestProgressCell.m in Sources */,
-				B57D0F4812AA7D3600E5F992 /* ASIWebPageRequest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -827,6 +642,11 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/External/GHUnit/__MACOSX\"",
+					"\"$(SRCROOT)/External/GHUnit\"",
+				);
 				GCC_C_LANGUAGE_STANDARD = "compiler-default";
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -836,9 +656,18 @@
 				HEADER_SEARCH_PATHS = "${SDK_DIR}/usr/include/libxml2";
 				INFOPLIST_FILE = "iPhone Sample/iPhoneInfo.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 3.1.3;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)\"",
+				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-all_load",
+				);
 				PRODUCT_NAME = "ASIHTTPRequest iPhone";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				TARGETED_DEVICE_FAMILY = 1;
+				USER_HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/asihttp $(SRCROOT)/Classes $(SRCROOT)/External";
 			};
 			name = Debug;
 		};
@@ -848,15 +677,29 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/External/GHUnit/__MACOSX\"",
+					"\"$(SRCROOT)/External/GHUnit\"",
+				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "iPhone Sample/iPhone_Prefix.pch";
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				HEADER_SEARCH_PATHS = "${SDK_DIR}/usr/include/libxml2";
 				INFOPLIST_FILE = "iPhone Sample/iPhoneInfo.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 3.1.3;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)\"",
+				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-all_load",
+				);
 				PRODUCT_NAME = "ASIHTTPRequest iPhone";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				TARGETED_DEVICE_FAMILY = 1;
+				USER_HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/asihttp $(SRCROOT)/Classes $(SRCROOT)/External";
 			};
 			name = Release;
 		};
@@ -881,13 +724,17 @@
 				HEADER_SEARCH_PATHS = "${SDK_DIR}/usr/include/libxml2";
 				INFOPLIST_FILE = "iPhone Sample/Tests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 3.2.2;
-				LIBRARY_SEARCH_PATHS = "";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-all_load",
 				);
 				PRODUCT_NAME = Tests;
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
+				USER_HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/asihttp";
 				WARNING_CFLAGS = "";
 			};
 			name = Debug;
@@ -914,7 +761,10 @@
 				INFOPLIST_FILE = "iPhone Sample/Tests-Info.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
 				IPHONEOS_DEPLOYMENT_TARGET = 3.2.2;
-				LIBRARY_SEARCH_PATHS = "";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-all_load",
@@ -923,6 +773,7 @@
 				PRODUCT_NAME = Tests;
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
+				USER_HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/asihttp";
 			};
 			name = Release;
 		};
@@ -942,8 +793,17 @@
 				HEADER_SEARCH_PATHS = "${SDK_DIR}/usr/include/libxml2";
 				INFOPLIST_FILE = "iPhone Sample/iPadInfo.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 3.2;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)\"",
+				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-all_load",
+				);
 				PRODUCT_NAME = "ASIHTTPRequest iPad";
 				TARGETED_DEVICE_FAMILY = 2;
+				USER_HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/asihttp $(SRCROOT)/Classes $(SRCROOT)/External";
 			};
 			name = Debug;
 		};
@@ -960,8 +820,17 @@
 				HEADER_SEARCH_PATHS = "${SDK_DIR}/usr/include/libxml2";
 				INFOPLIST_FILE = "iPhone Sample/iPadInfo.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 3.2;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)\"",
+				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-all_load",
+				);
 				PRODUCT_NAME = "ASIHTTPRequest iPad";
 				TARGETED_DEVICE_FAMILY = 2;
+				USER_HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/asihttp $(SRCROOT)/Classes $(SRCROOT)/External";
 			};
 			name = Release;
 		};
@@ -1004,7 +873,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B55B60CE0F765BB10064029C /* Build configuration list for PBXNativeTarget "Tests" */ = {
+		B55B60CE0F765BB10064029C /* Build configuration list for PBXNativeTarget "iOS Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				B55B60CC0F765BB10064029C /* Debug */,

--- a/iPhone.xcodeproj/project.pbxproj
+++ b/iPhone.xcodeproj/project.pbxproj
@@ -110,6 +110,34 @@
 		B5FE752711DBBA6400F898C8 /* ASIDownloadCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FE752511DBBA6400F898C8 /* ASIDownloadCache.m */; };
 		B5FE752811DBBA6400F898C8 /* ASIDownloadCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FE752511DBBA6400F898C8 /* ASIDownloadCache.m */; };
 		B5FE752911DBBA6400F898C8 /* ASIDownloadCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FE752511DBBA6400F898C8 /* ASIDownloadCache.m */; };
+		D355C1C6134BBE4100AD1FE7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D52C11C7CEFA0059B815 /* Foundation.framework */; };
+		D355C1CE134BBE5200AD1FE7 /* ASIHTTPRequestConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = B551DB4610D6938500EC1CBF /* ASIHTTPRequestConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D355C1CF134BBE5200AD1FE7 /* ASICacheDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = B5FE752A11DBBA6A00F898C8 /* ASICacheDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D355C1D0134BBE5200AD1FE7 /* ASIHTTPRequestDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = B5747F271174BB8300C9414E /* ASIHTTPRequestDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D355C1D1134BBE5200AD1FE7 /* ASIProgressDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = B5747F281174BB8300C9414E /* ASIProgressDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D355C1D4134BBE5200AD1FE7 /* ASIInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = B522DACC1030B2AB009A2D22 /* ASIInputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D355C1D5134BBE5200AD1FE7 /* ASIInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = B522DACD1030B2AB009A2D22 /* ASIInputStream.m */; };
+		D355C1D6134BBE5200AD1FE7 /* ASIFormDataRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = B55B60450F765A320064029C /* ASIFormDataRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D355C1D7134BBE5200AD1FE7 /* ASIFormDataRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60460F765A320064029C /* ASIFormDataRequest.m */; };
+		D355C1D8134BBE5200AD1FE7 /* ASIHTTPRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = B55B60470F765A320064029C /* ASIHTTPRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D355C1D9134BBE5200AD1FE7 /* ASIHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60480F765A320064029C /* ASIHTTPRequest.m */; };
+		D355C1DA134BBE5200AD1FE7 /* ASINetworkQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = B55B60490F765A320064029C /* ASINetworkQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D355C1DB134BBE5200AD1FE7 /* ASINetworkQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B604A0F765A320064029C /* ASINetworkQueue.m */; };
+		D355C1DC134BBE5200AD1FE7 /* ASIDownloadCache.h in Headers */ = {isa = PBXBuildFile; fileRef = B5FE752611DBBA6400F898C8 /* ASIDownloadCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D355C1DD134BBE5200AD1FE7 /* ASIDownloadCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FE752511DBBA6400F898C8 /* ASIDownloadCache.m */; };
+		D355C1DE134BBE5200AD1FE7 /* ASIDataDecompressor.h in Headers */ = {isa = PBXBuildFile; fileRef = B53E6D921257B45800C1E79A /* ASIDataDecompressor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D355C1DF134BBE5200AD1FE7 /* ASIDataDecompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = B53E6D911257B45800C1E79A /* ASIDataDecompressor.m */; };
+		D355C1E0134BBE5200AD1FE7 /* ASIDataCompressor.h in Headers */ = {isa = PBXBuildFile; fileRef = B53E6D941257B45800C1E79A /* ASIDataCompressor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D355C1E1134BBE5200AD1FE7 /* ASIDataCompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = B53E6D931257B45800C1E79A /* ASIDataCompressor.m */; };
+		D355C1E2134BBE5C00AD1FE7 /* Reachability.h in Headers */ = {isa = PBXBuildFile; fileRef = B55252B211D22E2200F9B170 /* Reachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D355C1E3134BBE5C00AD1FE7 /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = B55252B311D22E2200F9B170 /* Reachability.m */; };
+		D355C1E4134BBEB200AD1FE7 /* ASIAuthenticationDialog.h in Headers */ = {isa = PBXBuildFile; fileRef = B59A87C0103EC6F200300252 /* ASIAuthenticationDialog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D355C1E5134BBEB200AD1FE7 /* ASIAuthenticationDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = B59A87C1103EC6F200300252 /* ASIAuthenticationDialog.m */; };
+		D355C1E7134BBEF000AD1FE7 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D355C1E6134BBEF000AD1FE7 /* CFNetwork.framework */; };
+		D355C1E9134BBEF700AD1FE7 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D355C1E8134BBEF700AD1FE7 /* SystemConfiguration.framework */; };
+		D355C1EB134BBEFE00AD1FE7 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D355C1EA134BBEFE00AD1FE7 /* MobileCoreServices.framework */; };
+		D355C1ED134BBF0600AD1FE7 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D355C1EC134BBF0600AD1FE7 /* CoreGraphics.framework */; };
+		D355C1EF134BBF2100AD1FE7 /* libz.1.2.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D355C1EE134BBF2100AD1FE7 /* libz.1.2.3.dylib */; };
 		DADCEB8512D5039F00958557 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D4C011C7CC970059B815 /* CFNetwork.framework */; };
 		DADCEB8612D503AD00958557 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D4C011C7CC970059B815 /* CFNetwork.framework */; };
 		DADCEB8A12D503F500958557 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D4D011C7CCBC0059B815 /* CoreGraphics.framework */; };
@@ -267,6 +295,13 @@
 		B5FE752511DBBA6400F898C8 /* ASIDownloadCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIDownloadCache.m; sourceTree = "<group>"; };
 		B5FE752611DBBA6400F898C8 /* ASIDownloadCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIDownloadCache.h; sourceTree = "<group>"; };
 		B5FE752A11DBBA6A00F898C8 /* ASICacheDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICacheDelegate.h; sourceTree = "<group>"; };
+		D355C1C5134BBE4100AD1FE7 /* libASIHTTPRequest.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libASIHTTPRequest.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		D355C1C9134BBE4100AD1FE7 /* ASIHTTPRequest-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ASIHTTPRequest-Prefix.pch"; sourceTree = "<group>"; };
+		D355C1E6134BBEF000AD1FE7 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		D355C1E8134BBEF700AD1FE7 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		D355C1EA134BBEFE00AD1FE7 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		D355C1EC134BBF0600AD1FE7 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		D355C1EE134BBF2100AD1FE7 /* libz.1.2.3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.2.3.dylib; path = usr/lib/libz.1.2.3.dylib; sourceTree = SDKROOT; };
 		DADCEB9812D5057700958557 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = /usr/lib/libxml2.dylib; sourceTree = "<absolute>"; };
 		DADCEB9E12D505AB00958557 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = /usr/lib/libz.dylib; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
@@ -319,6 +354,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D355C1C2134BBE4100AD1FE7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D355C1EF134BBF2100AD1FE7 /* libz.1.2.3.dylib in Frameworks */,
+				D355C1ED134BBF0600AD1FE7 /* CoreGraphics.framework in Frameworks */,
+				D355C1EB134BBEFE00AD1FE7 /* MobileCoreServices.framework in Frameworks */,
+				D355C1E9134BBEF700AD1FE7 /* SystemConfiguration.framework in Frameworks */,
+				D355C1E7134BBEF000AD1FE7 /* CFNetwork.framework in Frameworks */,
+				D355C1C6134BBE4100AD1FE7 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -359,6 +407,7 @@
 				1D6058910D05DD3D006BFB54 /* ASIHTTPRequest iPhone.app */,
 				B55B60C70F765BB00064029C /* Tests.app */,
 				B576D72311C7F34D0059B815 /* ASIHTTPRequest iPad.app */,
+				D355C1C5134BBE4100AD1FE7 /* libASIHTTPRequest.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -366,10 +415,16 @@
 		29B97314FDCFA39411CA2CEA /* iPhone */ = {
 			isa = PBXGroup;
 			children = (
+				D355C1EE134BBF2100AD1FE7 /* libz.1.2.3.dylib */,
+				D355C1EC134BBF0600AD1FE7 /* CoreGraphics.framework */,
+				D355C1EA134BBEFE00AD1FE7 /* MobileCoreServices.framework */,
+				D355C1E8134BBEF700AD1FE7 /* SystemConfiguration.framework */,
+				D355C1E6134BBEF000AD1FE7 /* CFNetwork.framework */,
 				B5D1454E1029E20D004379B8 /* External */,
 				080E96DDFE201D6D7F000001 /* Classes */,
 				29B97315FDCFA39411CA2CEA /* Other Sources */,
 				29B97317FDCFA39411CA2CEA /* Resources */,
+				D355C1C7134BBE4100AD1FE7 /* ASIHTTPRequest */,
 				29B97323FDCFA39411CA2CEA /* Frameworks */,
 				19C28FACFE9D520D11CA2CBB /* Products */,
 			);
@@ -552,7 +607,46 @@
 			path = External;
 			sourceTree = "<group>";
 		};
+		D355C1C7134BBE4100AD1FE7 /* ASIHTTPRequest */ = {
+			isa = PBXGroup;
+			children = (
+				D355C1C8134BBE4100AD1FE7 /* Supporting Files */,
+			);
+			path = ASIHTTPRequest;
+			sourceTree = "<group>";
+		};
+		D355C1C8134BBE4100AD1FE7 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				D355C1C9134BBE4100AD1FE7 /* ASIHTTPRequest-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		D355C1C3134BBE4100AD1FE7 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D355C1CE134BBE5200AD1FE7 /* ASIHTTPRequestConfig.h in Headers */,
+				D355C1CF134BBE5200AD1FE7 /* ASICacheDelegate.h in Headers */,
+				D355C1D0134BBE5200AD1FE7 /* ASIHTTPRequestDelegate.h in Headers */,
+				D355C1D1134BBE5200AD1FE7 /* ASIProgressDelegate.h in Headers */,
+				D355C1D4134BBE5200AD1FE7 /* ASIInputStream.h in Headers */,
+				D355C1D6134BBE5200AD1FE7 /* ASIFormDataRequest.h in Headers */,
+				D355C1D8134BBE5200AD1FE7 /* ASIHTTPRequest.h in Headers */,
+				D355C1DA134BBE5200AD1FE7 /* ASINetworkQueue.h in Headers */,
+				D355C1DC134BBE5200AD1FE7 /* ASIDownloadCache.h in Headers */,
+				D355C1DE134BBE5200AD1FE7 /* ASIDataDecompressor.h in Headers */,
+				D355C1E0134BBE5200AD1FE7 /* ASIDataCompressor.h in Headers */,
+				D355C1E2134BBE5C00AD1FE7 /* Reachability.h in Headers */,
+				D355C1E4134BBEB200AD1FE7 /* ASIAuthenticationDialog.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		1D6058900D05DD3D006BFB54 /* iPhone */ = {
@@ -610,6 +704,23 @@
 			productReference = B576D72311C7F34D0059B815 /* ASIHTTPRequest iPad.app */;
 			productType = "com.apple.product-type.application";
 		};
+		D355C1C4134BBE4100AD1FE7 /* ASIHTTPRequest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D355C1CC134BBE4100AD1FE7 /* Build configuration list for PBXNativeTarget "ASIHTTPRequest" */;
+			buildPhases = (
+				D355C1C1134BBE4100AD1FE7 /* Sources */,
+				D355C1C2134BBE4100AD1FE7 /* Frameworks */,
+				D355C1C3134BBE4100AD1FE7 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ASIHTTPRequest;
+			productName = ASIHTTPRequest;
+			productReference = D355C1C5134BBE4100AD1FE7 /* libASIHTTPRequest.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -632,6 +743,7 @@
 				1D6058900D05DD3D006BFB54 /* iPhone */,
 				B55B60C60F765BB00064029C /* Tests */,
 				B576D70211C7F34D0059B815 /* iPad */,
+				D355C1C4134BBE4100AD1FE7 /* ASIHTTPRequest */,
 			);
 		};
 /* End PBXProject section */
@@ -818,6 +930,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D355C1C1134BBE4100AD1FE7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D355C1D5134BBE5200AD1FE7 /* ASIInputStream.m in Sources */,
+				D355C1D7134BBE5200AD1FE7 /* ASIFormDataRequest.m in Sources */,
+				D355C1D9134BBE5200AD1FE7 /* ASIHTTPRequest.m in Sources */,
+				D355C1DB134BBE5200AD1FE7 /* ASINetworkQueue.m in Sources */,
+				D355C1DD134BBE5200AD1FE7 /* ASIDownloadCache.m in Sources */,
+				D355C1DF134BBE5200AD1FE7 /* ASIDataDecompressor.m in Sources */,
+				D355C1E1134BBE5200AD1FE7 /* ASIDataCompressor.m in Sources */,
+				D355C1E3134BBE5C00AD1FE7 /* Reachability.m in Sources */,
+				D355C1E5134BBEB200AD1FE7 /* ASIAuthenticationDialog.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
@@ -992,6 +1120,45 @@
 			};
 			name = Release;
 		};
+		D355C1CA134BBE4100AD1FE7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				DSTROOT = /tmp/ASIHTTPRequest.dst;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "ASIHTTPRequest/ASIHTTPRequest-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		D355C1CB134BBE4100AD1FE7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				DSTROOT = /tmp/ASIHTTPRequest.dst;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "ASIHTTPRequest/ASIHTTPRequest-Prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1030,6 +1197,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		D355C1CC134BBE4100AD1FE7 /* Build configuration list for PBXNativeTarget "ASIHTTPRequest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D355C1CA134BBE4100AD1FE7 /* Debug */,
+				D355C1CB134BBE4100AD1FE7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/iPhone.xcodeproj/project.pbxproj
+++ b/iPhone.xcodeproj/project.pbxproj
@@ -110,34 +110,6 @@
 		B5FE752711DBBA6400F898C8 /* ASIDownloadCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FE752511DBBA6400F898C8 /* ASIDownloadCache.m */; };
 		B5FE752811DBBA6400F898C8 /* ASIDownloadCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FE752511DBBA6400F898C8 /* ASIDownloadCache.m */; };
 		B5FE752911DBBA6400F898C8 /* ASIDownloadCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FE752511DBBA6400F898C8 /* ASIDownloadCache.m */; };
-		D355C1C6134BBE4100AD1FE7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D52C11C7CEFA0059B815 /* Foundation.framework */; };
-		D355C1CE134BBE5200AD1FE7 /* ASIHTTPRequestConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = B551DB4610D6938500EC1CBF /* ASIHTTPRequestConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D355C1CF134BBE5200AD1FE7 /* ASICacheDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = B5FE752A11DBBA6A00F898C8 /* ASICacheDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D355C1D0134BBE5200AD1FE7 /* ASIHTTPRequestDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = B5747F271174BB8300C9414E /* ASIHTTPRequestDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D355C1D1134BBE5200AD1FE7 /* ASIProgressDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = B5747F281174BB8300C9414E /* ASIProgressDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D355C1D4134BBE5200AD1FE7 /* ASIInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = B522DACC1030B2AB009A2D22 /* ASIInputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D355C1D5134BBE5200AD1FE7 /* ASIInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = B522DACD1030B2AB009A2D22 /* ASIInputStream.m */; };
-		D355C1D6134BBE5200AD1FE7 /* ASIFormDataRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = B55B60450F765A320064029C /* ASIFormDataRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D355C1D7134BBE5200AD1FE7 /* ASIFormDataRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60460F765A320064029C /* ASIFormDataRequest.m */; };
-		D355C1D8134BBE5200AD1FE7 /* ASIHTTPRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = B55B60470F765A320064029C /* ASIHTTPRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D355C1D9134BBE5200AD1FE7 /* ASIHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B60480F765A320064029C /* ASIHTTPRequest.m */; };
-		D355C1DA134BBE5200AD1FE7 /* ASINetworkQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = B55B60490F765A320064029C /* ASINetworkQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D355C1DB134BBE5200AD1FE7 /* ASINetworkQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = B55B604A0F765A320064029C /* ASINetworkQueue.m */; };
-		D355C1DC134BBE5200AD1FE7 /* ASIDownloadCache.h in Headers */ = {isa = PBXBuildFile; fileRef = B5FE752611DBBA6400F898C8 /* ASIDownloadCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D355C1DD134BBE5200AD1FE7 /* ASIDownloadCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FE752511DBBA6400F898C8 /* ASIDownloadCache.m */; };
-		D355C1DE134BBE5200AD1FE7 /* ASIDataDecompressor.h in Headers */ = {isa = PBXBuildFile; fileRef = B53E6D921257B45800C1E79A /* ASIDataDecompressor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D355C1DF134BBE5200AD1FE7 /* ASIDataDecompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = B53E6D911257B45800C1E79A /* ASIDataDecompressor.m */; };
-		D355C1E0134BBE5200AD1FE7 /* ASIDataCompressor.h in Headers */ = {isa = PBXBuildFile; fileRef = B53E6D941257B45800C1E79A /* ASIDataCompressor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D355C1E1134BBE5200AD1FE7 /* ASIDataCompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = B53E6D931257B45800C1E79A /* ASIDataCompressor.m */; };
-		D355C1E2134BBE5C00AD1FE7 /* Reachability.h in Headers */ = {isa = PBXBuildFile; fileRef = B55252B211D22E2200F9B170 /* Reachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D355C1E3134BBE5C00AD1FE7 /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = B55252B311D22E2200F9B170 /* Reachability.m */; };
-		D355C1E4134BBEB200AD1FE7 /* ASIAuthenticationDialog.h in Headers */ = {isa = PBXBuildFile; fileRef = B59A87C0103EC6F200300252 /* ASIAuthenticationDialog.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D355C1E5134BBEB200AD1FE7 /* ASIAuthenticationDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = B59A87C1103EC6F200300252 /* ASIAuthenticationDialog.m */; };
-		D355C1E7134BBEF000AD1FE7 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D355C1E6134BBEF000AD1FE7 /* CFNetwork.framework */; };
-		D355C1E9134BBEF700AD1FE7 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D355C1E8134BBEF700AD1FE7 /* SystemConfiguration.framework */; };
-		D355C1EB134BBEFE00AD1FE7 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D355C1EA134BBEFE00AD1FE7 /* MobileCoreServices.framework */; };
-		D355C1ED134BBF0600AD1FE7 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D355C1EC134BBF0600AD1FE7 /* CoreGraphics.framework */; };
-		D355C1EF134BBF2100AD1FE7 /* libz.1.2.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D355C1EE134BBF2100AD1FE7 /* libz.1.2.3.dylib */; };
 		DADCEB8512D5039F00958557 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D4C011C7CC970059B815 /* CFNetwork.framework */; };
 		DADCEB8612D503AD00958557 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D4C011C7CC970059B815 /* CFNetwork.framework */; };
 		DADCEB8A12D503F500958557 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B576D4D011C7CCBC0059B815 /* CoreGraphics.framework */; };
@@ -295,13 +267,6 @@
 		B5FE752511DBBA6400F898C8 /* ASIDownloadCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIDownloadCache.m; sourceTree = "<group>"; };
 		B5FE752611DBBA6400F898C8 /* ASIDownloadCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIDownloadCache.h; sourceTree = "<group>"; };
 		B5FE752A11DBBA6A00F898C8 /* ASICacheDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICacheDelegate.h; sourceTree = "<group>"; };
-		D355C1C5134BBE4100AD1FE7 /* libASIHTTPRequest.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libASIHTTPRequest.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		D355C1C9134BBE4100AD1FE7 /* ASIHTTPRequest-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ASIHTTPRequest-Prefix.pch"; sourceTree = "<group>"; };
-		D355C1E6134BBEF000AD1FE7 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
-		D355C1E8134BBEF700AD1FE7 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
-		D355C1EA134BBEFE00AD1FE7 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
-		D355C1EC134BBF0600AD1FE7 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
-		D355C1EE134BBF2100AD1FE7 /* libz.1.2.3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.2.3.dylib; path = usr/lib/libz.1.2.3.dylib; sourceTree = SDKROOT; };
 		DADCEB9812D5057700958557 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = /usr/lib/libxml2.dylib; sourceTree = "<absolute>"; };
 		DADCEB9E12D505AB00958557 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = /usr/lib/libz.dylib; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
@@ -354,19 +319,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D355C1C2134BBE4100AD1FE7 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D355C1EF134BBF2100AD1FE7 /* libz.1.2.3.dylib in Frameworks */,
-				D355C1ED134BBF0600AD1FE7 /* CoreGraphics.framework in Frameworks */,
-				D355C1EB134BBEFE00AD1FE7 /* MobileCoreServices.framework in Frameworks */,
-				D355C1E9134BBEF700AD1FE7 /* SystemConfiguration.framework in Frameworks */,
-				D355C1E7134BBEF000AD1FE7 /* CFNetwork.framework in Frameworks */,
-				D355C1C6134BBE4100AD1FE7 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -407,7 +359,6 @@
 				1D6058910D05DD3D006BFB54 /* ASIHTTPRequest iPhone.app */,
 				B55B60C70F765BB00064029C /* Tests.app */,
 				B576D72311C7F34D0059B815 /* ASIHTTPRequest iPad.app */,
-				D355C1C5134BBE4100AD1FE7 /* libASIHTTPRequest.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -415,16 +366,10 @@
 		29B97314FDCFA39411CA2CEA /* iPhone */ = {
 			isa = PBXGroup;
 			children = (
-				D355C1EE134BBF2100AD1FE7 /* libz.1.2.3.dylib */,
-				D355C1EC134BBF0600AD1FE7 /* CoreGraphics.framework */,
-				D355C1EA134BBEFE00AD1FE7 /* MobileCoreServices.framework */,
-				D355C1E8134BBEF700AD1FE7 /* SystemConfiguration.framework */,
-				D355C1E6134BBEF000AD1FE7 /* CFNetwork.framework */,
 				B5D1454E1029E20D004379B8 /* External */,
 				080E96DDFE201D6D7F000001 /* Classes */,
 				29B97315FDCFA39411CA2CEA /* Other Sources */,
 				29B97317FDCFA39411CA2CEA /* Resources */,
-				D355C1C7134BBE4100AD1FE7 /* ASIHTTPRequest */,
 				29B97323FDCFA39411CA2CEA /* Frameworks */,
 				19C28FACFE9D520D11CA2CBB /* Products */,
 			);
@@ -607,46 +552,7 @@
 			path = External;
 			sourceTree = "<group>";
 		};
-		D355C1C7134BBE4100AD1FE7 /* ASIHTTPRequest */ = {
-			isa = PBXGroup;
-			children = (
-				D355C1C8134BBE4100AD1FE7 /* Supporting Files */,
-			);
-			path = ASIHTTPRequest;
-			sourceTree = "<group>";
-		};
-		D355C1C8134BBE4100AD1FE7 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				D355C1C9134BBE4100AD1FE7 /* ASIHTTPRequest-Prefix.pch */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
-
-/* Begin PBXHeadersBuildPhase section */
-		D355C1C3134BBE4100AD1FE7 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D355C1CE134BBE5200AD1FE7 /* ASIHTTPRequestConfig.h in Headers */,
-				D355C1CF134BBE5200AD1FE7 /* ASICacheDelegate.h in Headers */,
-				D355C1D0134BBE5200AD1FE7 /* ASIHTTPRequestDelegate.h in Headers */,
-				D355C1D1134BBE5200AD1FE7 /* ASIProgressDelegate.h in Headers */,
-				D355C1D4134BBE5200AD1FE7 /* ASIInputStream.h in Headers */,
-				D355C1D6134BBE5200AD1FE7 /* ASIFormDataRequest.h in Headers */,
-				D355C1D8134BBE5200AD1FE7 /* ASIHTTPRequest.h in Headers */,
-				D355C1DA134BBE5200AD1FE7 /* ASINetworkQueue.h in Headers */,
-				D355C1DC134BBE5200AD1FE7 /* ASIDownloadCache.h in Headers */,
-				D355C1DE134BBE5200AD1FE7 /* ASIDataDecompressor.h in Headers */,
-				D355C1E0134BBE5200AD1FE7 /* ASIDataCompressor.h in Headers */,
-				D355C1E2134BBE5C00AD1FE7 /* Reachability.h in Headers */,
-				D355C1E4134BBEB200AD1FE7 /* ASIAuthenticationDialog.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		1D6058900D05DD3D006BFB54 /* iPhone */ = {
@@ -704,23 +610,6 @@
 			productReference = B576D72311C7F34D0059B815 /* ASIHTTPRequest iPad.app */;
 			productType = "com.apple.product-type.application";
 		};
-		D355C1C4134BBE4100AD1FE7 /* ASIHTTPRequest */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = D355C1CC134BBE4100AD1FE7 /* Build configuration list for PBXNativeTarget "ASIHTTPRequest" */;
-			buildPhases = (
-				D355C1C1134BBE4100AD1FE7 /* Sources */,
-				D355C1C2134BBE4100AD1FE7 /* Frameworks */,
-				D355C1C3134BBE4100AD1FE7 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = ASIHTTPRequest;
-			productName = ASIHTTPRequest;
-			productReference = D355C1C5134BBE4100AD1FE7 /* libASIHTTPRequest.a */;
-			productType = "com.apple.product-type.library.static";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -743,7 +632,6 @@
 				1D6058900D05DD3D006BFB54 /* iPhone */,
 				B55B60C60F765BB00064029C /* Tests */,
 				B576D70211C7F34D0059B815 /* iPad */,
-				D355C1C4134BBE4100AD1FE7 /* ASIHTTPRequest */,
 			);
 		};
 /* End PBXProject section */
@@ -930,22 +818,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D355C1C1134BBE4100AD1FE7 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D355C1D5134BBE5200AD1FE7 /* ASIInputStream.m in Sources */,
-				D355C1D7134BBE5200AD1FE7 /* ASIFormDataRequest.m in Sources */,
-				D355C1D9134BBE5200AD1FE7 /* ASIHTTPRequest.m in Sources */,
-				D355C1DB134BBE5200AD1FE7 /* ASINetworkQueue.m in Sources */,
-				D355C1DD134BBE5200AD1FE7 /* ASIDownloadCache.m in Sources */,
-				D355C1DF134BBE5200AD1FE7 /* ASIDataDecompressor.m in Sources */,
-				D355C1E1134BBE5200AD1FE7 /* ASIDataCompressor.m in Sources */,
-				D355C1E3134BBE5C00AD1FE7 /* Reachability.m in Sources */,
-				D355C1E5134BBEB200AD1FE7 /* ASIAuthenticationDialog.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
@@ -1120,45 +992,6 @@
 			};
 			name = Release;
 		};
-		D355C1CA134BBE4100AD1FE7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				DSTROOT = /tmp/ASIHTTPRequest.dst;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ASIHTTPRequest/ASIHTTPRequest-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
-				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		D355C1CB134BBE4100AD1FE7 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				DSTROOT = /tmp/ASIHTTPRequest.dst;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ASIHTTPRequest/ASIHTTPRequest-Prefix.pch";
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
-				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1197,14 +1030,6 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
-		};
-		D355C1CC134BBE4100AD1FE7 /* Build configuration list for PBXNativeTarget "ASIHTTPRequest" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				D355C1CA134BBE4100AD1FE7 /* Debug */,
-				D355C1CB134BBE4100AD1FE7 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/libasihttp.xcodeproj/project.pbxproj
+++ b/libasihttp.xcodeproj/project.pbxproj
@@ -441,9 +441,12 @@
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				HEADER_SEARCH_PATHS = "${SDK_DIR}/usr/include/libxml2";
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
 				PREBINDING = NO;
 				PRODUCT_NAME = asihttp;
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -455,9 +458,12 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				HEADER_SEARCH_PATHS = "${SDK_DIR}/usr/include/libxml2";
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
 				PREBINDING = NO;
 				PRODUCT_NAME = asihttp;
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				ZERO_LINK = NO;
 			};
 			name = Release;

--- a/libasihttp.xcodeproj/project.pbxproj
+++ b/libasihttp.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		A8C61822132E3A52004B153D /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C6167D132E2DCF004B153D /* CFNetwork.framework */; };
-		A8C61823132E3A52004B153D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C6167E132E2DCF004B153D /* CoreGraphics.framework */; };
 		A8C61824132E3A52004B153D /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C61680132E2DCF004B153D /* MobileCoreServices.framework */; };
 		A8C61825132E3A52004B153D /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C61681132E2DCF004B153D /* Security.framework */; };
 		A8C61826132E3A52004B153D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C61682132E2DCF004B153D /* SystemConfiguration.framework */; };
@@ -70,7 +69,6 @@
 
 /* Begin PBXFileReference section */
 		A8C6167D132E2DCF004B153D /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
-		A8C6167E132E2DCF004B153D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		A8C61680132E2DCF004B153D /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		A8C61681132E2DCF004B153D /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		A8C61682132E2DCF004B153D /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
@@ -137,7 +135,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				A8C61822132E3A52004B153D /* CFNetwork.framework in Frameworks */,
-				A8C61823132E3A52004B153D /* CoreGraphics.framework in Frameworks */,
 				A8C61824132E3A52004B153D /* MobileCoreServices.framework in Frameworks */,
 				A8C61825132E3A52004B153D /* Security.framework in Frameworks */,
 				A8C61826132E3A52004B153D /* SystemConfiguration.framework in Frameworks */,
@@ -175,7 +172,6 @@
 			isa = PBXGroup;
 			children = (
 				A8C6167D132E2DCF004B153D /* CFNetwork.framework */,
-				A8C6167E132E2DCF004B153D /* CoreGraphics.framework */,
 				A8C61680132E2DCF004B153D /* MobileCoreServices.framework */,
 				A8C61681132E2DCF004B153D /* Security.framework */,
 				A8C61682132E2DCF004B153D /* SystemConfiguration.framework */,

--- a/libasihttp.xcodeproj/project.pbxproj
+++ b/libasihttp.xcodeproj/project.pbxproj
@@ -1,0 +1,489 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A8C61822132E3A52004B153D /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C6167D132E2DCF004B153D /* CFNetwork.framework */; };
+		A8C61823132E3A52004B153D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C6167E132E2DCF004B153D /* CoreGraphics.framework */; };
+		A8C61824132E3A52004B153D /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C61680132E2DCF004B153D /* MobileCoreServices.framework */; };
+		A8C61825132E3A52004B153D /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C61681132E2DCF004B153D /* Security.framework */; };
+		A8C61826132E3A52004B153D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C61682132E2DCF004B153D /* SystemConfiguration.framework */; };
+		A8C61827132E3A52004B153D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C61683132E2DCF004B153D /* UIKit.framework */; };
+		A8C61828132E3A52004B153D /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C61684132E2DCF004B153D /* libxml2.dylib */; };
+		A8C61829132E3A52004B153D /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C61685132E2DCF004B153D /* libz.dylib */; };
+		A8C6182A132E3A52004B153D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AACBBE490F95108600F1A2B1 /* Foundation.framework */; };
+		A8C61832132E3A96004B153D /* Reachability.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616C7132E398E004B153D /* Reachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61833132E3A96004B153D /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616C8132E398E004B153D /* Reachability.m */; };
+		A8C61835132E3AA0004B153D /* ASIHTTPRequestConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616CA132E3996004B153D /* ASIHTTPRequestConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61836132E3AA0004B153D /* ASICacheDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616CB132E3996004B153D /* ASICacheDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61837132E3AA0004B153D /* ASIHTTPRequestDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616CC132E3996004B153D /* ASIHTTPRequestDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61838132E3AA0004B153D /* ASIProgressDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616CD132E3996004B153D /* ASIProgressDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61839132E3AA0004B153D /* ASIAuthenticationDialog.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616CE132E3996004B153D /* ASIAuthenticationDialog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C6183A132E3AA0004B153D /* ASIAuthenticationDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616CF132E3996004B153D /* ASIAuthenticationDialog.m */; };
+		A8C6183B132E3AA0004B153D /* ASIInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616D0132E3996004B153D /* ASIInputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C6183C132E3AA0004B153D /* ASIInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616D1132E3996004B153D /* ASIInputStream.m */; };
+		A8C6183D132E3AA0004B153D /* ASIFormDataRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616D2132E3996004B153D /* ASIFormDataRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C6183E132E3AA0004B153D /* ASIFormDataRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616D3132E3996004B153D /* ASIFormDataRequest.m */; };
+		A8C6183F132E3AA0004B153D /* ASIHTTPRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616D4132E3996004B153D /* ASIHTTPRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61840132E3AA0004B153D /* ASIHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616D5132E3996004B153D /* ASIHTTPRequest.m */; };
+		A8C61841132E3AA0004B153D /* ASINetworkQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616D6132E3996004B153D /* ASINetworkQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61842132E3AA0004B153D /* ASINetworkQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616D7132E3996004B153D /* ASINetworkQueue.m */; };
+		A8C61843132E3AA0004B153D /* ASIDownloadCache.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616D8132E3996004B153D /* ASIDownloadCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61844132E3AA0004B153D /* ASIDownloadCache.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616D9132E3996004B153D /* ASIDownloadCache.m */; };
+		A8C61845132E3AA0004B153D /* ASIDataDecompressor.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616DA132E3996004B153D /* ASIDataDecompressor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61846132E3AA0004B153D /* ASIDataDecompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616DB132E3996004B153D /* ASIDataDecompressor.m */; };
+		A8C61847132E3AA0004B153D /* ASIDataCompressor.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616DC132E3996004B153D /* ASIDataCompressor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61848132E3AAD004B153D /* ASIWebPageRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616DF132E3996004B153D /* ASIWebPageRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61849132E3AAD004B153D /* ASIWebPageRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616E0132E3996004B153D /* ASIWebPageRequest.m */; };
+		A8C6184A132E3AD1004B153D /* ASIS3Bucket.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616E2132E3996004B153D /* ASIS3Bucket.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C6184B132E3AD1004B153D /* ASIS3Bucket.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616E3132E3996004B153D /* ASIS3Bucket.m */; };
+		A8C6184C132E3AD1004B153D /* ASIS3BucketRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616E4132E3996004B153D /* ASIS3BucketRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C6184D132E3AD1004B153D /* ASIS3BucketRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616E5132E3996004B153D /* ASIS3BucketRequest.m */; };
+		A8C6184E132E3AD1004B153D /* ASIS3ObjectRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616E6132E3996004B153D /* ASIS3ObjectRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C6184F132E3AD1004B153D /* ASIS3ObjectRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616E7132E3996004B153D /* ASIS3ObjectRequest.m */; };
+		A8C61850132E3AD1004B153D /* ASIS3ServiceRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616E8132E3996004B153D /* ASIS3ServiceRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61851132E3AD1004B153D /* ASIS3ServiceRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616E9132E3996004B153D /* ASIS3ServiceRequest.m */; };
+		A8C61852132E3AD1004B153D /* ASIS3BucketObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616EA132E3996004B153D /* ASIS3BucketObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61853132E3AD1004B153D /* ASIS3BucketObject.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616EB132E3996004B153D /* ASIS3BucketObject.m */; };
+		A8C61854132E3AD1004B153D /* ASIS3Request.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616EC132E3996004B153D /* ASIS3Request.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61855132E3AD1004B153D /* ASIS3Request.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616ED132E3996004B153D /* ASIS3Request.m */; };
+		A8C61857132E3AD7004B153D /* ASICloudFilesCDNRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616EF132E3996004B153D /* ASICloudFilesCDNRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61858132E3AD7004B153D /* ASICloudFilesCDNRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616F0132E3996004B153D /* ASICloudFilesCDNRequest.m */; };
+		A8C61859132E3AD7004B153D /* ASICloudFilesContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616F1132E3996004B153D /* ASICloudFilesContainer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C6185A132E3AD7004B153D /* ASICloudFilesContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616F2132E3996004B153D /* ASICloudFilesContainer.m */; };
+		A8C6185B132E3AD7004B153D /* ASICloudFilesContainerRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616F3132E3996004B153D /* ASICloudFilesContainerRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C6185C132E3AD7004B153D /* ASICloudFilesContainerRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616F4132E3996004B153D /* ASICloudFilesContainerRequest.m */; };
+		A8C6185D132E3AD7004B153D /* ASICloudFilesContainerXMLParserDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616F5132E3996004B153D /* ASICloudFilesContainerXMLParserDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C6185E132E3AD7004B153D /* ASICloudFilesContainerXMLParserDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616F6132E3996004B153D /* ASICloudFilesContainerXMLParserDelegate.m */; };
+		A8C6185F132E3AD7004B153D /* ASICloudFilesObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616F7132E3996004B153D /* ASICloudFilesObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61860132E3AD7004B153D /* ASICloudFilesObject.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616F8132E3996004B153D /* ASICloudFilesObject.m */; };
+		A8C61861132E3AD7004B153D /* ASICloudFilesObjectRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616F9132E3996004B153D /* ASICloudFilesObjectRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61862132E3AD7004B153D /* ASICloudFilesObjectRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616FA132E3996004B153D /* ASICloudFilesObjectRequest.m */; };
+		A8C61863132E3AD7004B153D /* ASICloudFilesRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C616FB132E3996004B153D /* ASICloudFilesRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8C61864132E3AD7004B153D /* ASICloudFilesRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616FC132E3996004B153D /* ASICloudFilesRequest.m */; };
+		A8C61865132E3AD9004B153D /* ASIDataCompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C616DD132E3996004B153D /* ASIDataCompressor.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		A8C6167D132E2DCF004B153D /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		A8C6167E132E2DCF004B153D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		A8C61680132E2DCF004B153D /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		A8C61681132E2DCF004B153D /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		A8C61682132E2DCF004B153D /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		A8C61683132E2DCF004B153D /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		A8C61684132E2DCF004B153D /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = /usr/lib/libxml2.dylib; sourceTree = "<absolute>"; };
+		A8C61685132E2DCF004B153D /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = /usr/lib/libz.dylib; sourceTree = "<absolute>"; };
+		A8C616C7132E398E004B153D /* Reachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Reachability.h; sourceTree = "<group>"; };
+		A8C616C8132E398E004B153D /* Reachability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Reachability.m; sourceTree = "<group>"; };
+		A8C616CA132E3996004B153D /* ASIHTTPRequestConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIHTTPRequestConfig.h; sourceTree = "<group>"; };
+		A8C616CB132E3996004B153D /* ASICacheDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICacheDelegate.h; sourceTree = "<group>"; };
+		A8C616CC132E3996004B153D /* ASIHTTPRequestDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIHTTPRequestDelegate.h; sourceTree = "<group>"; };
+		A8C616CD132E3996004B153D /* ASIProgressDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIProgressDelegate.h; sourceTree = "<group>"; };
+		A8C616CE132E3996004B153D /* ASIAuthenticationDialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIAuthenticationDialog.h; sourceTree = "<group>"; };
+		A8C616CF132E3996004B153D /* ASIAuthenticationDialog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIAuthenticationDialog.m; sourceTree = "<group>"; };
+		A8C616D0132E3996004B153D /* ASIInputStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIInputStream.h; sourceTree = "<group>"; };
+		A8C616D1132E3996004B153D /* ASIInputStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIInputStream.m; sourceTree = "<group>"; };
+		A8C616D2132E3996004B153D /* ASIFormDataRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIFormDataRequest.h; sourceTree = "<group>"; };
+		A8C616D3132E3996004B153D /* ASIFormDataRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIFormDataRequest.m; sourceTree = "<group>"; };
+		A8C616D4132E3996004B153D /* ASIHTTPRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIHTTPRequest.h; sourceTree = "<group>"; };
+		A8C616D5132E3996004B153D /* ASIHTTPRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIHTTPRequest.m; sourceTree = "<group>"; };
+		A8C616D6132E3996004B153D /* ASINetworkQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASINetworkQueue.h; sourceTree = "<group>"; };
+		A8C616D7132E3996004B153D /* ASINetworkQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASINetworkQueue.m; sourceTree = "<group>"; };
+		A8C616D8132E3996004B153D /* ASIDownloadCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIDownloadCache.h; sourceTree = "<group>"; };
+		A8C616D9132E3996004B153D /* ASIDownloadCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIDownloadCache.m; sourceTree = "<group>"; };
+		A8C616DA132E3996004B153D /* ASIDataDecompressor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIDataDecompressor.h; sourceTree = "<group>"; };
+		A8C616DB132E3996004B153D /* ASIDataDecompressor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIDataDecompressor.m; sourceTree = "<group>"; };
+		A8C616DC132E3996004B153D /* ASIDataCompressor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIDataCompressor.h; sourceTree = "<group>"; };
+		A8C616DD132E3996004B153D /* ASIDataCompressor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIDataCompressor.m; sourceTree = "<group>"; };
+		A8C616DF132E3996004B153D /* ASIWebPageRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASIWebPageRequest.h; path = ASIWebPageRequest/ASIWebPageRequest.h; sourceTree = "<group>"; };
+		A8C616E0132E3996004B153D /* ASIWebPageRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASIWebPageRequest.m; path = ASIWebPageRequest/ASIWebPageRequest.m; sourceTree = "<group>"; };
+		A8C616E2132E3996004B153D /* ASIS3Bucket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIS3Bucket.h; sourceTree = "<group>"; };
+		A8C616E3132E3996004B153D /* ASIS3Bucket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIS3Bucket.m; sourceTree = "<group>"; };
+		A8C616E4132E3996004B153D /* ASIS3BucketRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIS3BucketRequest.h; sourceTree = "<group>"; };
+		A8C616E5132E3996004B153D /* ASIS3BucketRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIS3BucketRequest.m; sourceTree = "<group>"; };
+		A8C616E6132E3996004B153D /* ASIS3ObjectRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIS3ObjectRequest.h; sourceTree = "<group>"; };
+		A8C616E7132E3996004B153D /* ASIS3ObjectRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIS3ObjectRequest.m; sourceTree = "<group>"; };
+		A8C616E8132E3996004B153D /* ASIS3ServiceRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIS3ServiceRequest.h; sourceTree = "<group>"; };
+		A8C616E9132E3996004B153D /* ASIS3ServiceRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIS3ServiceRequest.m; sourceTree = "<group>"; };
+		A8C616EA132E3996004B153D /* ASIS3BucketObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIS3BucketObject.h; sourceTree = "<group>"; };
+		A8C616EB132E3996004B153D /* ASIS3BucketObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIS3BucketObject.m; sourceTree = "<group>"; };
+		A8C616EC132E3996004B153D /* ASIS3Request.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIS3Request.h; sourceTree = "<group>"; };
+		A8C616ED132E3996004B153D /* ASIS3Request.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIS3Request.m; sourceTree = "<group>"; };
+		A8C616EF132E3996004B153D /* ASICloudFilesCDNRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesCDNRequest.h; sourceTree = "<group>"; };
+		A8C616F0132E3996004B153D /* ASICloudFilesCDNRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesCDNRequest.m; sourceTree = "<group>"; };
+		A8C616F1132E3996004B153D /* ASICloudFilesContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesContainer.h; sourceTree = "<group>"; };
+		A8C616F2132E3996004B153D /* ASICloudFilesContainer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesContainer.m; sourceTree = "<group>"; };
+		A8C616F3132E3996004B153D /* ASICloudFilesContainerRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesContainerRequest.h; sourceTree = "<group>"; };
+		A8C616F4132E3996004B153D /* ASICloudFilesContainerRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesContainerRequest.m; sourceTree = "<group>"; };
+		A8C616F5132E3996004B153D /* ASICloudFilesContainerXMLParserDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesContainerXMLParserDelegate.h; sourceTree = "<group>"; };
+		A8C616F6132E3996004B153D /* ASICloudFilesContainerXMLParserDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesContainerXMLParserDelegate.m; sourceTree = "<group>"; };
+		A8C616F7132E3996004B153D /* ASICloudFilesObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesObject.h; sourceTree = "<group>"; };
+		A8C616F8132E3996004B153D /* ASICloudFilesObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesObject.m; sourceTree = "<group>"; };
+		A8C616F9132E3996004B153D /* ASICloudFilesObjectRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesObjectRequest.h; sourceTree = "<group>"; };
+		A8C616FA132E3996004B153D /* ASICloudFilesObjectRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesObjectRequest.m; sourceTree = "<group>"; };
+		A8C616FB132E3996004B153D /* ASICloudFilesRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASICloudFilesRequest.h; sourceTree = "<group>"; };
+		A8C616FC132E3996004B153D /* ASICloudFilesRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASICloudFilesRequest.m; sourceTree = "<group>"; };
+		A8C61856132E3AD1004B153D /* libasihttp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libasihttp.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		AACBBE490F95108600F1A2B1 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A8C61725132E3A2C004B153D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A8C61822132E3A52004B153D /* CFNetwork.framework in Frameworks */,
+				A8C61823132E3A52004B153D /* CoreGraphics.framework in Frameworks */,
+				A8C61824132E3A52004B153D /* MobileCoreServices.framework in Frameworks */,
+				A8C61825132E3A52004B153D /* Security.framework in Frameworks */,
+				A8C61826132E3A52004B153D /* SystemConfiguration.framework in Frameworks */,
+				A8C61827132E3A52004B153D /* UIKit.framework in Frameworks */,
+				A8C61828132E3A52004B153D /* libxml2.dylib in Frameworks */,
+				A8C61829132E3A52004B153D /* libz.dylib in Frameworks */,
+				A8C6182A132E3A52004B153D /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		034768DFFF38A50411DB9C8B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A8C61856132E3AD1004B153D /* libasihttp.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		0867D691FE84028FC02AAC07 /* Static Library */ = {
+			isa = PBXGroup;
+			children = (
+				A8C616C5132E398E004B153D /* External */,
+				A8C616C9132E3996004B153D /* Classes */,
+				32C88DFF0371C24200C91783 /* Other Sources */,
+				0867D69AFE84028FC02AAC07 /* Frameworks */,
+				034768DFFF38A50411DB9C8B /* Products */,
+			);
+			name = "Static Library";
+			sourceTree = "<group>";
+		};
+		0867D69AFE84028FC02AAC07 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				A8C6167D132E2DCF004B153D /* CFNetwork.framework */,
+				A8C6167E132E2DCF004B153D /* CoreGraphics.framework */,
+				A8C61680132E2DCF004B153D /* MobileCoreServices.framework */,
+				A8C61681132E2DCF004B153D /* Security.framework */,
+				A8C61682132E2DCF004B153D /* SystemConfiguration.framework */,
+				A8C61683132E2DCF004B153D /* UIKit.framework */,
+				A8C61684132E2DCF004B153D /* libxml2.dylib */,
+				A8C61685132E2DCF004B153D /* libz.dylib */,
+				AACBBE490F95108600F1A2B1 /* Foundation.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		32C88DFF0371C24200C91783 /* Other Sources */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = "Other Sources";
+			sourceTree = "<group>";
+		};
+		A8C616C5132E398E004B153D /* External */ = {
+			isa = PBXGroup;
+			children = (
+				A8C616C6132E398E004B153D /* Reachability */,
+			);
+			path = External;
+			sourceTree = "<group>";
+		};
+		A8C616C6132E398E004B153D /* Reachability */ = {
+			isa = PBXGroup;
+			children = (
+				A8C616C7132E398E004B153D /* Reachability.h */,
+				A8C616C8132E398E004B153D /* Reachability.m */,
+			);
+			path = Reachability;
+			sourceTree = "<group>";
+		};
+		A8C616C9132E3996004B153D /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				A8C616DE132E3996004B153D /* ASIWebPageRequest */,
+				A8C616CA132E3996004B153D /* ASIHTTPRequestConfig.h */,
+				A8C616CB132E3996004B153D /* ASICacheDelegate.h */,
+				A8C616CC132E3996004B153D /* ASIHTTPRequestDelegate.h */,
+				A8C616CD132E3996004B153D /* ASIProgressDelegate.h */,
+				A8C616CE132E3996004B153D /* ASIAuthenticationDialog.h */,
+				A8C616CF132E3996004B153D /* ASIAuthenticationDialog.m */,
+				A8C616D0132E3996004B153D /* ASIInputStream.h */,
+				A8C616D1132E3996004B153D /* ASIInputStream.m */,
+				A8C616D2132E3996004B153D /* ASIFormDataRequest.h */,
+				A8C616D3132E3996004B153D /* ASIFormDataRequest.m */,
+				A8C616D4132E3996004B153D /* ASIHTTPRequest.h */,
+				A8C616D5132E3996004B153D /* ASIHTTPRequest.m */,
+				A8C616D6132E3996004B153D /* ASINetworkQueue.h */,
+				A8C616D7132E3996004B153D /* ASINetworkQueue.m */,
+				A8C616D8132E3996004B153D /* ASIDownloadCache.h */,
+				A8C616D9132E3996004B153D /* ASIDownloadCache.m */,
+				A8C616DA132E3996004B153D /* ASIDataDecompressor.h */,
+				A8C616DB132E3996004B153D /* ASIDataDecompressor.m */,
+				A8C616DC132E3996004B153D /* ASIDataCompressor.h */,
+				A8C616E1132E3996004B153D /* S3 */,
+				A8C616EE132E3996004B153D /* CloudFiles */,
+				A8C616DD132E3996004B153D /* ASIDataCompressor.m */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		A8C616DE132E3996004B153D /* ASIWebPageRequest */ = {
+			isa = PBXGroup;
+			children = (
+				A8C616DF132E3996004B153D /* ASIWebPageRequest.h */,
+				A8C616E0132E3996004B153D /* ASIWebPageRequest.m */,
+			);
+			name = ASIWebPageRequest;
+			sourceTree = "<group>";
+		};
+		A8C616E1132E3996004B153D /* S3 */ = {
+			isa = PBXGroup;
+			children = (
+				A8C616E2132E3996004B153D /* ASIS3Bucket.h */,
+				A8C616E3132E3996004B153D /* ASIS3Bucket.m */,
+				A8C616E4132E3996004B153D /* ASIS3BucketRequest.h */,
+				A8C616E5132E3996004B153D /* ASIS3BucketRequest.m */,
+				A8C616E6132E3996004B153D /* ASIS3ObjectRequest.h */,
+				A8C616E7132E3996004B153D /* ASIS3ObjectRequest.m */,
+				A8C616E8132E3996004B153D /* ASIS3ServiceRequest.h */,
+				A8C616E9132E3996004B153D /* ASIS3ServiceRequest.m */,
+				A8C616EA132E3996004B153D /* ASIS3BucketObject.h */,
+				A8C616EB132E3996004B153D /* ASIS3BucketObject.m */,
+				A8C616EC132E3996004B153D /* ASIS3Request.h */,
+				A8C616ED132E3996004B153D /* ASIS3Request.m */,
+			);
+			path = S3;
+			sourceTree = "<group>";
+		};
+		A8C616EE132E3996004B153D /* CloudFiles */ = {
+			isa = PBXGroup;
+			children = (
+				A8C616EF132E3996004B153D /* ASICloudFilesCDNRequest.h */,
+				A8C616F0132E3996004B153D /* ASICloudFilesCDNRequest.m */,
+				A8C616F1132E3996004B153D /* ASICloudFilesContainer.h */,
+				A8C616F2132E3996004B153D /* ASICloudFilesContainer.m */,
+				A8C616F3132E3996004B153D /* ASICloudFilesContainerRequest.h */,
+				A8C616F4132E3996004B153D /* ASICloudFilesContainerRequest.m */,
+				A8C616F5132E3996004B153D /* ASICloudFilesContainerXMLParserDelegate.h */,
+				A8C616F6132E3996004B153D /* ASICloudFilesContainerXMLParserDelegate.m */,
+				A8C616F7132E3996004B153D /* ASICloudFilesObject.h */,
+				A8C616F8132E3996004B153D /* ASICloudFilesObject.m */,
+				A8C616F9132E3996004B153D /* ASICloudFilesObjectRequest.h */,
+				A8C616FA132E3996004B153D /* ASICloudFilesObjectRequest.m */,
+				A8C616FB132E3996004B153D /* ASICloudFilesRequest.h */,
+				A8C616FC132E3996004B153D /* ASICloudFilesRequest.m */,
+			);
+			path = CloudFiles;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		A8C61723132E3A2C004B153D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A8C61857132E3AD7004B153D /* ASICloudFilesCDNRequest.h in Headers */,
+				A8C61859132E3AD7004B153D /* ASICloudFilesContainer.h in Headers */,
+				A8C6185B132E3AD7004B153D /* ASICloudFilesContainerRequest.h in Headers */,
+				A8C6185D132E3AD7004B153D /* ASICloudFilesContainerXMLParserDelegate.h in Headers */,
+				A8C6185F132E3AD7004B153D /* ASICloudFilesObject.h in Headers */,
+				A8C61861132E3AD7004B153D /* ASICloudFilesObjectRequest.h in Headers */,
+				A8C61863132E3AD7004B153D /* ASICloudFilesRequest.h in Headers */,
+				A8C6184A132E3AD1004B153D /* ASIS3Bucket.h in Headers */,
+				A8C6184C132E3AD1004B153D /* ASIS3BucketRequest.h in Headers */,
+				A8C6184E132E3AD1004B153D /* ASIS3ObjectRequest.h in Headers */,
+				A8C61850132E3AD1004B153D /* ASIS3ServiceRequest.h in Headers */,
+				A8C61852132E3AD1004B153D /* ASIS3BucketObject.h in Headers */,
+				A8C61854132E3AD1004B153D /* ASIS3Request.h in Headers */,
+				A8C61848132E3AAD004B153D /* ASIWebPageRequest.h in Headers */,
+				A8C61835132E3AA0004B153D /* ASIHTTPRequestConfig.h in Headers */,
+				A8C61836132E3AA0004B153D /* ASICacheDelegate.h in Headers */,
+				A8C61837132E3AA0004B153D /* ASIHTTPRequestDelegate.h in Headers */,
+				A8C61838132E3AA0004B153D /* ASIProgressDelegate.h in Headers */,
+				A8C61839132E3AA0004B153D /* ASIAuthenticationDialog.h in Headers */,
+				A8C6183B132E3AA0004B153D /* ASIInputStream.h in Headers */,
+				A8C6183D132E3AA0004B153D /* ASIFormDataRequest.h in Headers */,
+				A8C6183F132E3AA0004B153D /* ASIHTTPRequest.h in Headers */,
+				A8C61841132E3AA0004B153D /* ASINetworkQueue.h in Headers */,
+				A8C61843132E3AA0004B153D /* ASIDownloadCache.h in Headers */,
+				A8C61845132E3AA0004B153D /* ASIDataDecompressor.h in Headers */,
+				A8C61847132E3AA0004B153D /* ASIDataCompressor.h in Headers */,
+				A8C61832132E3A96004B153D /* Reachability.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		A8C61726132E3A2C004B153D /* asihttp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A8C6182F132E3A70004B153D /* Build configuration list for PBXNativeTarget "asihttp" */;
+			buildPhases = (
+				A8C61723132E3A2C004B153D /* Headers */,
+				A8C61724132E3A2C004B153D /* Sources */,
+				A8C61725132E3A2C004B153D /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = asihttp;
+			productName = libasihttp;
+			productReference = A8C61856132E3AD1004B153D /* libasihttp.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0867D690FE84028FC02AAC07 /* Project object */ = {
+			isa = PBXProject;
+			buildConfigurationList = 1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "libasihttp" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
+			mainGroup = 0867D691FE84028FC02AAC07 /* Static Library */;
+			productRefGroup = 034768DFFF38A50411DB9C8B /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A8C61726132E3A2C004B153D /* asihttp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A8C61724132E3A2C004B153D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A8C61865132E3AD9004B153D /* ASIDataCompressor.m in Sources */,
+				A8C61858132E3AD7004B153D /* ASICloudFilesCDNRequest.m in Sources */,
+				A8C6185A132E3AD7004B153D /* ASICloudFilesContainer.m in Sources */,
+				A8C6185C132E3AD7004B153D /* ASICloudFilesContainerRequest.m in Sources */,
+				A8C6185E132E3AD7004B153D /* ASICloudFilesContainerXMLParserDelegate.m in Sources */,
+				A8C61860132E3AD7004B153D /* ASICloudFilesObject.m in Sources */,
+				A8C61862132E3AD7004B153D /* ASICloudFilesObjectRequest.m in Sources */,
+				A8C61864132E3AD7004B153D /* ASICloudFilesRequest.m in Sources */,
+				A8C6184B132E3AD1004B153D /* ASIS3Bucket.m in Sources */,
+				A8C6184D132E3AD1004B153D /* ASIS3BucketRequest.m in Sources */,
+				A8C6184F132E3AD1004B153D /* ASIS3ObjectRequest.m in Sources */,
+				A8C61851132E3AD1004B153D /* ASIS3ServiceRequest.m in Sources */,
+				A8C61853132E3AD1004B153D /* ASIS3BucketObject.m in Sources */,
+				A8C61855132E3AD1004B153D /* ASIS3Request.m in Sources */,
+				A8C61849132E3AAD004B153D /* ASIWebPageRequest.m in Sources */,
+				A8C6183A132E3AA0004B153D /* ASIAuthenticationDialog.m in Sources */,
+				A8C6183C132E3AA0004B153D /* ASIInputStream.m in Sources */,
+				A8C6183E132E3AA0004B153D /* ASIFormDataRequest.m in Sources */,
+				A8C61840132E3AA0004B153D /* ASIHTTPRequest.m in Sources */,
+				A8C61842132E3AA0004B153D /* ASINetworkQueue.m in Sources */,
+				A8C61844132E3AA0004B153D /* ASIDownloadCache.m in Sources */,
+				A8C61846132E3AA0004B153D /* ASIDataDecompressor.m in Sources */,
+				A8C61833132E3A96004B153D /* Reachability.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		1DEB922308733DC00010E9CD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PREBINDING = NO;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		1DEB922408733DC00010E9CD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PREBINDING = NO;
+				SDKROOT = iphoneos;
+			};
+			name = Release;
+		};
+		A8C61728132E3A2D004B153D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				HEADER_SEARCH_PATHS = "${SDK_DIR}/usr/include/libxml2";
+				PREBINDING = NO;
+				PRODUCT_NAME = asihttp;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		A8C61729132E3A2D004B153D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_ENABLE_FIX_AND_CONTINUE = NO;
+				HEADER_SEARCH_PATHS = "${SDK_DIR}/usr/include/libxml2";
+				PREBINDING = NO;
+				PRODUCT_NAME = asihttp;
+				SDKROOT = iphoneos;
+				ZERO_LINK = NO;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "libasihttp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1DEB922308733DC00010E9CD /* Debug */,
+				1DEB922408733DC00010E9CD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A8C6182F132E3A70004B153D /* Build configuration list for PBXNativeTarget "asihttp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A8C61728132E3A2D004B153D /* Debug */,
+				A8C61729132E3A2D004B153D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0867D690FE84028FC02AAC07 /* Project object */;
+}


### PR DESCRIPTION
I grabbed root42's static library target and adapted it to match what I think is a reasonable project structure for Xcode 4 projects.

This branch includes an ASIHTTPRequest workspace which contains the Mac, iPhone, and libasihttp projects. 

The iPhone project has a dependency on the libasihttp static library build product instead of having both project reference the same sources. This way the iPhone project demonstrates use of ASI as a static library rather than recompiling the same code. 

The Mac project is unmodified.

I'm hopeful that this provides a simpler way for Xcode 4 users to include ASIHTTPRequest in their projects as the process for adding ASI to an existing project becomes:
1. Create a workspace containing your app's project.
2. Add the libasihttp project to your workspace.
3. Add libasihttp.a to your target's "Link Binary With Libraries" build phase.
4. Add "$(BUILT_PRODUCTS_DIR)/asihttp" to your target's "User Header Search Paths" build setting.
5. Add the libasihttp build target to your scheme before your application's target.

No more need to list out a long set of class files which should be added as references and libraries which must be linked against. Hopefully this pattern is not only easier to use but also makes it easier for users of ASI to pull down updates with more confidence that they won't have to figure out if the new version changes classes or introduces new code which must be added to their project. All the ASI headers are public for now but packaging everything in a static library would allow us to limit the publicly visible classes to provide a stable interface for other developers to work with.

I described the overall strategy I used to setup cross project dependencies within a workspace here: http://blog.carbonfive.com/2011/04/04/using-open-source-static-libraries-in-xcode-4/

Since the Xcode 3 installation instructions did not use the projects or build targets distributed with ASI I think that these changes do not prevent Xcode 3 users from using ASI. However Xcode 3 users are probably no longer able to build the targets in the iPhone project. If that's a concern please consider pulling this work into a branch instead of master. I think it would be helpful for Xcode 4 users and would love to see feedback on how well this sort of library structure works for sharing.
