### PR TITLE
Attempt to update wwan throttling code so that 3g performs better than 2g, but both still work

### DIFF
--- a/Classes/ASIHTTPRequest.h
+++ b/Classes/ASIHTTPRequest.h
@@ -71,7 +71,7 @@ extern NSString* const NetworkRequestErrorDomain;
 // You can use this number to throttle upload and download bandwidth in iPhone OS apps send or receive a large amount of data
 // This may help apps that might otherwise be rejected for inclusion into the app store for using excessive bandwidth
 // This number is not official, as far as I know there is no officially documented bandwidth limit
-extern unsigned long const ASIWWANBandwidthThrottleAmount;
+extern unsigned long const ASIWWANLowBandwidthThrottleAmount;
 
 #if NS_BLOCKS_AVAILABLE
 typedef void (^ASIBasicBlock)(void);

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -94,8 +94,28 @@ static NSLock *bandwidthThrottlingLock = nil;
 // the maximum number of bytes that can be transmitted in one second
 static unsigned long maxBandwidthPerSecond = 0;
 
-// A default figure for throttling bandwidth on mobile devices
-unsigned long const ASIWWANBandwidthThrottleAmount = 14800;
+// A default figure for throttling bandwidth on slower mobile devices
+// Docs suggest 5MB/5Min for entire device, this allows for some overhead
+// And some additional device traffic. This is absolutely not perfect, just
+// a good approximation.
+unsigned long const ASIWWANLowBandwidthThrottleAmount = 14800;
+
+// A default figure for throttling bandwidth on faster mobile connections
+unsigned long const ASIWWANHighBandwidthThrottleAmount = 148000;
+
+// If we don't get enough traffic during a bandwidthMeasurement cycle this is incremented
+// If we do get good bandwidth this is set back to 0
+static unsigned long wwanBandwidthStrikes = 0;
+
+// If bandwidth in a measurement cycle is less than this value we ignore the cycle
+unsigned long const ASIWWANMinBandwidthThreashold = 1024;
+
+// If bandwidth in a cycle is less than this value we increment wwanBandwidthStrikes
+unsigned long const ASIWWANMaxBandwidthThreashold = 65537;
+
+// When wwanBandwidthStrikes reaches this number, the WWAN throttle is downgraded
+unsigned long const ASIWWANBandwidthStrikesForFallback = 2;
+
 
 #if TARGET_OS_IPHONE
 // YES when bandwidth throttling is active
@@ -4270,8 +4290,23 @@ static NSOperationQueue *sharedQueue = nil;
 		}
 	}
 	#if DEBUG_THROTTLING
-	NSLog(@"===Used: %u bytes of bandwidth in last measurement period===",bandwidthUsedInLastSecond);
+	NSLog(@"===Used: %lu bytes of bandwidth in last measurement period===",bandwidthUsedInLastSecond);
 	#endif
+
+    if (maxBandwidthPerSecond > ASIWWANLowBandwidthThrottleAmount && bandwidthUsedInLastSecond > ASIWWANMinBandwidthThreashold && wwanBandwidthStrikes < ASIWWANBandwidthStrikesForFallback) {
+        if (bandwidthUsedInLastSecond < ASIWWANMaxBandwidthThreashold) {
+            wwanBandwidthStrikes++;
+            if (wwanBandwidthStrikes >= ASIWWANBandwidthStrikesForFallback) {
+                #if DEBUG_THROTTLING
+                NSLog(@"Reducing WWAN throttle to %ld bytes/second because of low bandwidth in %lu measurement cycles, bandwidth used in last second was %lu", ASIWWANBandwidthThrottleAmount, wwanBandwidthStrikes, bandwidthUsedInLastSecond);
+                #endif
+                maxBandwidthPerSecond = ASIWWANLowBandwidthThrottleAmount;
+            }
+        } else {
+            wwanBandwidthStrikes = 0;
+        }
+    }
+
 	[bandwidthUsageTracker addObject:[NSNumber numberWithUnsignedLong:bandwidthUsedInLastSecond]];
 	[bandwidthMeasurementDate release];
 	bandwidthMeasurementDate = [[NSDate dateWithTimeIntervalSinceNow:1] retain];
@@ -4351,7 +4386,9 @@ static NSOperationQueue *sharedQueue = nil;
 + (void)setShouldThrottleBandwidthForWWAN:(BOOL)throttle
 {
 	if (throttle) {
-		[ASIHTTPRequest throttleBandwidthForWWANUsingLimit:ASIWWANBandwidthThrottleAmount];
+        // Reset throttle and fallback strikes counter
+        [ASIHTTPRequest throttleBandwidthForWWANUsingLimit:ASIWWANHighBandwidthThrottleAmount];
+        wwanBandwidthStrikes = 0;
 	} else {
 		[ASIHTTPRequest unsubscribeFromNetworkReachabilityNotifications];
 		[ASIHTTPRequest setMaxBandwidthPerSecond:0];


### PR DESCRIPTION
Simple algorithm that attempts to make wwan bandwidth throttling code be reasonably fast on 3G, but still fall back on bad 3G or 2G/EDGE connection. I'm not super familiar with the ASI code base, so I'm not certain if this is the most general way of solving this issue, but it has worked very well in our testing. I create a new request object for each connection and turn the throttling on each time. I'm guessing there is a better place to reset the throttle and the low bandwidth strike count.

I've done a bunch of snooping around the net, it appears that AT&T is doing some sort of throttling for 2G/3G connections. I've seen comments about 5MB/5Min. In my testing this seems to be quite accurate for 2G connections. However, it's clearly possible to transfer quite a bit faster on 3G without being disconnected. The high speed throttle included here is really a first shot at finding a constant for 3G that is as reliable as the one you already had for 2G.

Based on all of my tests, I've been able to shield my iPhone on both 2G and 3G to get crappy reception and then make sure my connections are not being forcibly terminated. I've been able to cause timeout over both 2G and 3G with this code without being disconnected by the network. Transfers over 3G when the signal is reasonable, is way faster than it was previously.

The file I've been testing with is about 1MB and my use case is 99% upload and 1% download, so there likely needs to be more testing in other scenarios.
