### PR TITLE
readStream closing fix

### DIFF
--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -3716,6 +3716,7 @@ static NSOperationQueue *sharedQueue = nil;
 
 		CFReadStreamSetClient((CFReadStreamRef)[self readStream], kCFStreamEventNone, NULL, NULL);
 		[[self readStream] removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:[self runLoopMode]];
+		[[self readStream] close];
 		[self setReadStreamIsScheduled:NO];
 	}
 }

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -1436,6 +1436,7 @@ static NSOperationQueue *sharedQueue = nil;
 {
 	[self setURL:[self redirectURL]];
 	[self setComplete:YES];
+	[self destroyReadStream];
 	[self setNeedsRedirect:NO];
 	[self setRedirectCount:[self redirectCount]+1];
 


### PR DESCRIPTION
I ran into a consistently reproducible crasher when hitting the same url from two different reusable asihttprequest objects, one immediately after the other, where that url will redirect to another url and caching is set to ASIOnlyLoadIfNotCachedCachePolicy for both requests.

When rebuilding a reusable request to follow a redirect we need to make sure the old readStream is destroyed. There was previously no direct check on this. The old readStream is almost always done at this point, but the above example resulted in a case where the readStream for the original url of the second request object is not done at the time it gets redirected because its information is found in the cache after the first request object puts it there and we overwrite the second request objects original readStream while it is still returning data.

Detailed information is included in the commit log.
