### PR TITLE
Comment out logNetworkStatus_

### DIFF
--- a/External/Reachability/Reachability.m
+++ b/External/Reachability/Reachability.m
@@ -155,25 +155,25 @@ static void logReachabilityFlags_(const char *name, int line, SCNetworkReachabil
 
 #define logNetworkStatus(status) (logNetworkStatus_(__PRETTY_FUNCTION__, __LINE__, status))
 
-static void logNetworkStatus_(const char *name, int line, NetworkStatus status) {
-	
-	NSString *statusString = nil;
-	
-	switch (status) {
-		case kNotReachable:
-			statusString = [NSString stringWithString: @"Not Reachable"];
-			break;
-		case kReachableViaWWAN:
-			statusString = [NSString stringWithString: @"Reachable via WWAN"];
-			break;
-		case kReachableViaWiFi:
-			statusString = [NSString stringWithString: @"Reachable via WiFi"];
-			break;
-	}
-	
-	NSLog(@"%s (%d) \n\tNetwork Status: %@", name, line, statusString);
-	
-} // logNetworkStatus_()
+//static void logNetworkStatus_(const char *name, int line, NetworkStatus status) {
+//
+//	NSString *statusString = nil;
+//
+//	switch (status) {
+//		case kNotReachable:
+//			statusString = [NSString stringWithString: @"Not Reachable"];
+//			break;
+//		case kReachableViaWWAN:
+//			statusString = [NSString stringWithString: @"Reachable via WWAN"];
+//			break;
+//		case kReachableViaWiFi:
+//			statusString = [NSString stringWithString: @"Reachable via WiFi"];
+//			break;
+//	}
+//
+//	NSLog(@"%s (%d) \n\tNetwork Status: %@", name, line, statusString);
+//
+//} // logNetworkStatus_()
 
 #else
 #define logReachabilityFlags(flags)


### PR DESCRIPTION
The only call to logNetworkStatus is commented out (line 516), which
causes a compiler warning in DEBUG mode because logNetworkStatus_ is
defined but never used. This commit comments out the definition to
match the invocation.
