### PR TITLE
Cache Error with downloadDestinationPath, Not storing downloaded data

### DIFF
--- a/Classes/ASIDownloadCache.m
+++ b/Classes/ASIDownloadCache.m
@@ -183,9 +183,14 @@ static NSString *permanentCacheFolder = @"PermanentStore";
 
 	if ([request responseData]) {
 		[[request responseData] writeToFile:dataPath atomically:NO];
-	} else if ([request downloadDestinationPath] && ![[request downloadDestinationPath] isEqualToString:dataPath]) {
+	} else if ([request downloadDestinationPath] && ![[request downloadDestinationPath] isEqualToString:dataPath]) {        
 		NSError *error = nil;
-		[[[[NSFileManager alloc] init] autorelease] copyItemAtPath:[request downloadDestinationPath] toPath:dataPath error:&error];
+        NSFileManager* manager = [[NSFileManager alloc] init];
+        if ([manager fileExistsAtPath:dataPath]) {
+            [manager removeItemAtPath:dataPath error:&error];
+        }
+        [manager copyItemAtPath:[request downloadDestinationPath] toPath:dataPath error:&error];
+        [manager release];
 	}
 	[[self accessLock] unlock];
 }


### PR DESCRIPTION
I fixed a problem I noticed. If you use the cache to store files and you are storing using a downloadDestinationPath, the cache does not correctly copy over the new data.

The next time you download that url, it will return the old data. The fix is to delete the file before copying over the old one.
