### PR TITLE
Added VOIP property to CFStream for long lived background sockets

### DIFF
--- a/Classes/ASIHTTPRequest.h
+++ b/Classes/ASIHTTPRequest.h
@@ -992,6 +992,7 @@ typedef void (^ASIDataBlock)(NSData *data);
 @property (retain) NSArray *clientCertificates;
 #if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
 @property (assign) BOOL shouldContinueWhenAppEntersBackground;
+@property (assign) BOOL shouldUseVOIPSocket;
 #endif
 @property (retain) ASIDataDecompressor *dataDecompressor;
 @property (assign) BOOL shouldWaitToInflateCompressedResponses;

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -1356,6 +1356,21 @@ static NSOperationQueue *sharedQueue = nil;
 	}
 	
 	[connectionsLock unlock];
+    
+    // set the VOIP property if it was asked for
+#if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
+    if([self shouldUseVOIPSocket])
+    {
+        BOOL r1 = CFReadStreamSetProperty((CFReadStreamRef)[self readStream], kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);	
+        if (!r1)
+        {
+#ifdef DEBUG_REQUEST_STATUS
+            NSLog(@"[CONNECTION] Request %@ Error setting VOIP property", self);
+#endif
+        }
+    }
+#endif
+
 
 	// Schedule the stream
 	if (![self readStreamIsScheduled] && (!throttleWakeUpTime || [throttleWakeUpTime timeIntervalSinceDate:[NSDate date]] < 0)) {
@@ -5060,6 +5075,7 @@ static NSOperationQueue *sharedQueue = nil;
 @synthesize redirectURL;
 #if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
 @synthesize shouldContinueWhenAppEntersBackground;
+@synthesize shouldUseVOIPSocket;
 #endif
 @synthesize dataDecompressor;
 @synthesize shouldWaitToInflateCompressedResponses;


### PR DESCRIPTION
Added VOIP socket capability. Using this you can have a COMET Style long-lasting HTTP connection which will wake your iPhone app when data is available.

This requires that the VOIP background mode be set in the info.plist. Apple do approve apps with the VOIP property set, even if they aren't strictly 'voip' apps.

This is preferable to using beginBackgroundTask as that has a timeout of 10 minutes before the background task is terminated.

With this property you can effectively hold the socket open indefinitely and iOS will wake the app up when there is activity detected on the socket, you then get 10-30 seconds to process the incoming data (and create a new listening socket)
