### PR TITLE
Move expiryDateForRequest to ASIHTTPRequest

### DIFF
--- a/Classes/ASIDownloadCache.m
+++ b/Classes/ASIDownloadCache.m
@@ -105,31 +105,7 @@ static NSString *permanentCacheFolder = @"PermanentStore";
 
 - (NSDate *)expiryDateForRequest:(ASIHTTPRequest *)request maxAge:(NSTimeInterval)maxAge
 {
-	NSMutableDictionary *responseHeaders = [NSMutableDictionary dictionaryWithDictionary:[request responseHeaders]];
-
-	// If we weren't given a custom max-age, lets look for one in the response headers
-	if (!maxAge) {
-		NSString *cacheControl = [[responseHeaders objectForKey:@"Cache-Control"] lowercaseString];
-		if (cacheControl) {
-			NSScanner *scanner = [NSScanner scannerWithString:cacheControl];
-			[scanner scanUpToString:@"max-age" intoString:NULL];
-			if ([scanner scanString:@"max-age" intoString:NULL]) {
-				[scanner scanString:@"=" intoString:NULL];
-				[scanner scanDouble:&maxAge];
-			}
-		}
-	}
-
-	// RFC 2612 says max-age must override any Expires header
-	if (maxAge) {
-		return [[NSDate date] addTimeInterval:maxAge];
-	} else {
-		NSString *expires = [responseHeaders objectForKey:@"Expires"];
-		if (expires) {
-			return [ASIHTTPRequest dateFromRFC1123String:expires];
-		}
-	}
-	return nil;
+  return [ASIHTTPRequest expiryDateForRequest:request maxAge:maxAge];
 }
 
 - (void)storeResponseForRequest:(ASIHTTPRequest *)request maxAge:(NSTimeInterval)maxAge

--- a/Classes/ASIHTTPRequest.h
+++ b/Classes/ASIHTTPRequest.h
@@ -873,6 +873,11 @@ typedef void (^ASIDataBlock)(NSData *data);
 // And also by ASIS3Request
 + (NSString *)base64forData:(NSData *)theData;
 
+// Returns the expiration date for the request.
+// Calculated from the Expires response header property, unless maxAge is non-zero or
+// there exists a non-zero max-age property in the Cache-Control response header.
++ (NSDate *)expiryDateForRequest:(ASIHTTPRequest *)request maxAge:(NSTimeInterval)maxAge;
+
 // Returns a date from a string in RFC1123 format
 + (NSDate *)dateFromRFC1123String:(NSString *)string;
 


### PR DESCRIPTION
Make ASIDownloadCache's expiryDateForRequest a static method on ASIHTTPRequest so that the code can be reused.

The functionality is common enough that it may be advantageous for a third party looking at the request headers to use this method to calculate the request's expiry date.

Unit tests:
- No new tests.

Documentation:
- Documented the new method +expiryDateForRequest:maxAge:
