### PR TITLE
Solve building warning on Xcode 4.2 & iOS SDK 5.0

### DIFF
--- a/Classes/ASIAuthenticationDialog.m
+++ b/Classes/ASIAuthenticationDialog.m
@@ -133,7 +133,7 @@ static const NSUInteger kDomainSection = 1;
 {
 	[self showTitle];
 	
-	UIInterfaceOrientation o = [[UIApplication sharedApplication] statusBarOrientation];
+	UIInterfaceOrientation o = (UIInterfaceOrientation)[[UIApplication sharedApplication] statusBarOrientation];
 	CGFloat angle = 0;
 	switch (o) {
 		case UIDeviceOrientationLandscapeLeft: angle = 90; break;


### PR DESCRIPTION
Add (UIInterfaceOrientation) on:
UIInterfaceOrientation o = [[UIApplication sharedApplication] statusBarOrientation];
to solve building warning on XCode4.2 and iOS SDK 5.0
