### PR TITLE
Added SSL level, Correct enumeration type

### DIFF
--- a/Classes/ASIHTTPRequest.h
+++ b/Classes/ASIHTTPRequest.h
@@ -370,6 +370,10 @@ typedef void (^ASIDataBlock)(NSData *data);
     SecIdentityRef clientCertificateIdentity;
 	NSArray *clientCertificates;
 	
+    // Security level of a socket stream.
+    // By default, a stream’s security level is kCFStreamSocketSecurityLevelNegotiatedSSL.
+    NSString *securityLevel;
+
 	// Details on the proxy to use - you could set these yourself, but it's probably best to let ASIHTTPRequest detect the system proxy settings
 	NSString *proxyHost;
 	int proxyPort;
@@ -969,6 +973,7 @@ typedef void (^ASIDataBlock)(NSData *data);
 @property (assign, readonly) unsigned long long partialDownloadSize;
 @property (assign) BOOL shouldRedirect;
 @property (assign) BOOL validatesSecureCertificate;
+@property (retain) NSString *securityLevel;
 @property (assign) BOOL shouldCompressRequestBody;
 @property (retain) NSURL *PACurl;
 @property (retain) NSString *authenticationScheme;

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -298,6 +298,7 @@ static NSOperationQueue *sharedQueue = nil;
 	[self setUseSessionPersistence:YES];
 	[self setUseCookiePersistence:YES];
 	[self setValidatesSecureCertificate:YES];
+    [self setSecurityLevel:(NSString *)kCFStreamSocketSecurityLevelNegotiatedSSL];
 	[self setRequestCookies:[[[NSMutableArray alloc] init] autorelease]];
 	[self setDidStartSelector:@selector(requestStarted:)];
 	[self setDidReceiveResponseHeadersSelector:@selector(request:didReceiveResponseHeaders:)];
@@ -1243,6 +1244,10 @@ static NSOperationQueue *sharedQueue = nil;
             CFReadStreamSetProperty((CFReadStreamRef)[self readStream], kCFStreamPropertySSLSettings, sslProperties);
         }
         
+        // Tell CFNetwork to use specified security level for the socket stream
+        [sslProperties setObject:[self securityLevel] forKey:(NSString *)kCFStreamSSLLevel];
+        
+        CFReadStreamSetProperty((CFReadStreamRef)[self readStream], kCFStreamPropertySSLSettings, sslProperties);
     }
 
 	//
@@ -1641,6 +1646,7 @@ static NSOperationQueue *sharedQueue = nil;
 	[headRequest setValidatesSecureCertificate:[self validatesSecureCertificate]];
     [headRequest setClientCertificateIdentity:clientCertificateIdentity];
 	[headRequest setClientCertificates:[[clientCertificates copy] autorelease]];
+    [headRequest setSecurityLevel:[self securityLevel]];
 	[headRequest setPACurl:[self PACurl]];
 	[headRequest setShouldPresentCredentialsBeforeChallenge:[self shouldPresentCredentialsBeforeChallenge]];
 	[headRequest setNumberOfTimesToRetryOnTimeout:[self numberOfTimesToRetryOnTimeout]];
@@ -4092,6 +4098,7 @@ static NSOperationQueue *sharedQueue = nil;
 	[newRequest setValidatesSecureCertificate:[self validatesSecureCertificate]];
     [newRequest setClientCertificateIdentity:clientCertificateIdentity];
 	[newRequest setClientCertificates:[[clientCertificates copy] autorelease]];
+    [newRequest setSecurityLevel:[self securityLevel]];
 	[newRequest setPACurl:[self PACurl]];
 	[newRequest setShouldPresentCredentialsBeforeChallenge:[self shouldPresentCredentialsBeforeChallenge]];
 	[newRequest setNumberOfTimesToRetryOnTimeout:[self numberOfTimesToRetryOnTimeout]];
@@ -5072,6 +5079,7 @@ static NSOperationQueue *sharedQueue = nil;
 @synthesize updatedProgress;
 @synthesize shouldRedirect;
 @synthesize validatesSecureCertificate;
+@synthesize securityLevel;
 @synthesize needsRedirect;
 @synthesize redirectCount;
 @synthesize shouldCompressRequestBody;


### PR DESCRIPTION
- I needed to force my requests for a specific SSL level so that any secure request can be set with a specific security level of a socket stream
- Corrected various UIDeviceOrientation\* with UIInterfaceOrientation*
