### PR TITLE
CopyWithZone did not copy authenticationScheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ profile
 *.pbxuser
 *.mode1v3
 External/GHUnit/*
+.svn

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -4081,6 +4081,7 @@ static NSOperationQueue *sharedQueue = nil;
 	[newRequest setShouldUseRFC2616RedirectBehaviour:[self shouldUseRFC2616RedirectBehaviour]];
 	[newRequest setShouldAttemptPersistentConnection:[self shouldAttemptPersistentConnection]];
 	[newRequest setPersistentConnectionTimeoutSeconds:[self persistentConnectionTimeoutSeconds]];
+    [newRequest setAuthenticationScheme:[self authenticationScheme]];
 	return newRequest;
 }
 


### PR DESCRIPTION
The CopyWithZone method did not copy the authenticationScheme, resulting
in problems when using a copied ASIHTTPRequest.
