### PR TITLE
Small fix to the bandwidth throttler.

### DIFF
--- a/Classes/ASIInputStream.m
+++ b/Classes/ASIInputStream.m
@@ -58,9 +58,11 @@ static NSLock *readLock = nil;
 		}
 		[request performThrottling];
 	}
-	[ASIHTTPRequest incrementBandwidthUsedInLastSecond:toRead];
 	[readLock unlock];
-	return [stream read:buffer maxLength:toRead];
+	NSInteger rv = [stream read:buffer maxLength:toRead];
+	if (rv > 0)
+		[ASIHTTPRequest incrementBandwidthUsedInLastSecond:rv];
+	return rv;
 }
 
 /*


### PR DESCRIPTION
incorrectly charging the entire buffer size against the throttler
rather than just the number of bytes actually read.

For example, if you did a read with a 32KB buffer which only received
300 bytes across the wire, the bandwidth Throttler would charge
you for a full 32KB of bandwidth rather than the 300 bytes that
were really used.  This was grossly overstating the bandwidth
consumption to the throttler.
