### PR TITLE
Small fix to remove C++ compile errors.

### DIFF
--- a/Classes/ASIDataCompressor.m
+++ b/Classes/ASIDataCompressor.m
@@ -88,7 +88,7 @@
 			[outputData increaseLengthBy:halfLength];
 		}
 		
-		zStream.next_out = [outputData mutableBytes] + zStream.total_out-bytesProcessedAlready;
+		zStream.next_out = (Bytef*)[outputData mutableBytes] + zStream.total_out-bytesProcessedAlready;
 		zStream.avail_out = (unsigned int)([outputData length] - (zStream.total_out-bytesProcessedAlready));
 		status = deflate(&zStream, shouldFinish ? Z_FINISH : Z_NO_FLUSH);
 		
@@ -184,7 +184,7 @@
 		}
 		
 		// Write the deflated data out to the destination file
-		[outputStream write:[outputData bytes] maxLength:[outputData length]];
+		[outputStream write:(const uint8_t *)[outputData bytes] maxLength:[outputData length]];
 		
 		// Make sure nothing went wrong
 		if ([inputStream streamStatus] == NSStreamEventErrorOccurred) {


### PR DESCRIPTION
A friend ran into these compiler errors tonight:

```
../asihttprequest/ASIDataDecompressor.m: In function 'NSData* -[ASIDataDecompressor uncompressBytes:length:error:](ASIDataDecompressor*, objc_selector*, Bytef*, NSUInteger, NSError**)':
../asihttprequest/ASIDataDecompressor.m:89: error: pointer of type 'void *' used in arithmetic
../asihttprequest/ASIDataDecompressor.m:89: error: pointer of type 'void *' used in arithmetic
../asihttprequest/ASIDataDecompressor.m:89: error: invalid conversion from 'void*' to 'Bytef*'
../asihttprequest/ASIDataDecompressor.m: In function 'BOOL +[ASIDataDecompressor uncompressDataFromFile:toFile:error:](objc_object*, objc_selector*, NSString*, NSString*, NSError**)':
../asihttprequest/ASIDataDecompressor.m:192: error: invalid conversion from 'const void*' to 'const uint8_t*'
```

I looked around and found a few people had the same error, but that noone had found the answer[1]. It turns out this happens if `ASIDataCompressor.m` is compiled with the `objective-c++` flag, which can happen if the file type is set to `Objective-C++` or if the project or target is set to compile all obj-c files as objective-c++.

It's a tiny change to `ASIDataCompressor.m` to eliminate these compiler errors: Just cast two `void *` returns from `[NSData bytes]` to `Bytef *` and `const uint8_t *`

[1] http://www.google.com/search?sourceid=chrome&ie=UTF-8&q=ASIDataCompressor+pointer+arithmetic
