### PR TITLE
Added blocksupport to ASINetworkQueue

### DIFF
--- a/Classes/ASINetworkQueue.h
+++ b/Classes/ASINetworkQueue.h
@@ -10,6 +10,10 @@
 #import "ASIHTTPRequestDelegate.h"
 #import "ASIProgressDelegate.h"
 
+#if NS_BLOCKS_AVAILABLE
+typedef void (^ASIBasicQueueBlock)(void);
+#endif
+
 @interface ASINetworkQueue : NSOperationQueue <ASIProgressDelegate, ASIHTTPRequestDelegate, NSCopying> {
 	
 	// Delegate will get didFail + didFinish messages (if set)
@@ -69,6 +73,10 @@
 
 	// Storage container for additional queue information.
 	NSDictionary *userInfo;
+  
+	//block to execute when the queue has finished all requests (successfully or unsuccessfully)
+	ASIBasicQueueBlock queueDidFinishBlock;
+
 	
 }
 
@@ -84,6 +92,11 @@
 // All ASINetworkQueues are paused when created so that total size can be calculated before the queue starts
 // This method will start the queue
 - (void)go;
+
+#if NS_BLOCKS_AVAILABLE
+- (void)setQueueDidFinishBlock:(ASIBasicQueueBlock)aQueueDidFinishBlock;
+#endif
+
 
 @property (assign, nonatomic, setter=setUploadProgressDelegate:) id uploadProgressDelegate;
 @property (assign, nonatomic, setter=setDownloadProgressDelegate:) id downloadProgressDelegate;

--- a/Classes/ASINetworkQueue.m
+++ b/Classes/ASINetworkQueue.m
@@ -210,6 +210,12 @@
 		if ([self queueDidFinishSelector]) {
 			[[self delegate] performSelector:[self queueDidFinishSelector] withObject:self];
 		}
+  #if NS_BLOCKS_AVAILABLE
+    if(queueDidFinishBlock){
+      queueDidFinishBlock();
+    }
+  #endif
+
 	}
 }
 
@@ -223,6 +229,12 @@
 		if ([self queueDidFinishSelector]) {
 			[[self delegate] performSelector:[self queueDidFinishSelector] withObject:self];
 		}
+    #if NS_BLOCKS_AVAILABLE
+      if(queueDidFinishBlock){
+        queueDidFinishBlock();
+      }
+    #endif
+
 	}
 	if ([self shouldCancelAllRequestsOnFailure] && [self requestsCount] > 0) {
 		[self cancelAllOperations];
@@ -301,6 +313,16 @@
 	}
 	return [super respondsToSelector:selector];
 }
+
+#pragma mark blocks
+#if NS_BLOCKS_AVAILABLE
+- (void)setQueueDidFinishBlock:(ASIBasicBlock)aQueueDidFinishBlock
+{
+	[queueDidFinishBlock release];
+	queueDidFinishBlock = [aQueueDidFinishBlock copy];
+}
+#endif
+
 
 #pragma mark NSCopying
 


### PR DESCRIPTION
I had some issues with re-defined types for ASIBasicBlock so inside ASINetworkQUeue I named them ASIBasicQueueBlock
I just finished for queueDidFinishBlock - will support others later.
There is no releaseBlocksOnMainThread for the ASINetworkQueue. I haven't looked it through, will add it when I have checked it out more. Please use this Pull request to review the code. I don't expect an actual merge for now :) Sorry if it is bothersome.
We like blocks.
