### PR TITLE
Patched issue #263 (if needed)

### DIFF
--- a/Classes/ASIFormDataRequest.m
+++ b/Classes/ASIFormDataRequest.m
@@ -49,6 +49,7 @@
 	self = [super initWithURL:newURL];
 	[self setPostFormat:ASIURLEncodedPostFormat];
 	[self setStringEncoding:NSUTF8StringEncoding];
+    [self setRequestMethod:@"POST"];
 	return self;
 }
 

--- a/Classes/ASIFormDataRequest.m
+++ b/Classes/ASIFormDataRequest.m
@@ -49,7 +49,7 @@
 	self = [super initWithURL:newURL];
 	[self setPostFormat:ASIURLEncodedPostFormat];
 	[self setStringEncoding:NSUTF8StringEncoding];
-    [self setRequestMethod:@"POST"];
+        [self setRequestMethod:@"POST"];
 	return self;
 }
 

--- a/Classes/Tests/ASIFormDataRequestTests.h
+++ b/Classes/Tests/ASIFormDataRequestTests.h
@@ -12,6 +12,7 @@
 	float progress;
 }
 
+- (void)testDefaultMethod;
 - (void)testPostWithFileUpload;
 - (void)testEmptyData;
 - (void)testSubclass;
@@ -19,4 +20,5 @@
 - (void)testCharset;
 - (void)testPUT;
 - (void)testCopy;
+
 @end

--- a/Classes/Tests/ASIFormDataRequestTests.m
+++ b/Classes/Tests/ASIFormDataRequestTests.m
@@ -17,6 +17,14 @@
 
 @implementation ASIFormDataRequestTests
 
+
+-(void)testDefaultMethod
+{
+    ASIFormDataRequest *request = [[[ASIFormDataRequest alloc] initWithURL:[NSURL URLWithString:@"http://wedontcare.com"]] autorelease];
+    
+    GHAssertTrue([[request requestMethod] isEqualToString:@"POST"], @"Default request method should be POST");
+}
+
 - (void)testAddNilKeysAndValues
 {
 	ASIFormDataRequest *request = [ASIFormDataRequest requestWithURL:[NSURL URLWithString:@"http://allseeing-i.com/ASIHTTPRequest/tests/empty-post-value"]];


### PR DESCRIPTION
ASIFormDataRequest has a default 'GET' method (should be 'POST' by
default)
