### PR TITLE
Clean up the use of CFRunLoop.

### DIFF
--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -3507,7 +3507,7 @@ static NSOperationQueue *sharedQueue = nil;
 		
 	// If request has asked delegate or ASIAuthenticationDialog for credentials
 	} else if ([self authenticationNeeded]) {
-		CFRunLoopStop(CFRunLoopGetCurrent());
+        // Do nothing.
 	}
 
 }
@@ -3546,8 +3546,6 @@ static NSOperationQueue *sharedQueue = nil;
         [self didChangeValueForKey:@"isExecuting"];
     if (!wasFinished)
         [self didChangeValueForKey:@"isFinished"];
-
-	CFRunLoopStop(CFRunLoopGetCurrent());
 
 	#if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
 	if ([ASIHTTPRequest isMultitaskingSupported] && [self shouldContinueWhenAppEntersBackground]) {
@@ -4787,7 +4785,7 @@ static NSOperationQueue *sharedQueue = nil;
     BOOL runAlways = YES; // Introduced to cheat Static Analyzer
 	while (runAlways) {
 		NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-		CFRunLoopRun();
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1.0e10, true);
 		[pool drain];
 	}
 


### PR DESCRIPTION
Previously, tasks running from inside the CFRunLoop would call CFRunLoopStop prior to finishing execution. This results in non-deterministic failures to call endBackgroundTask when running iOS tasks in the background with beginBackgroundTaskWithExpirationHandler.
Since the only reason to break out of the CFRunLoop is to flush the autorelease pool, we instead invoke CFRunLoopRunInMode with returnAfterSourceHandled=True, which safely returns and flushes the autorelease pool after each invocation of the CFRunLoop.
