### PR TITLE
Fix for self-signed client certificates on iOS 5

### DIFF
--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -1200,41 +1200,40 @@ static NSOperationQueue *sharedQueue = nil;
 
     if([[[[self url] scheme] lowercaseString] isEqualToString:@"https"]) {       
        
+			NSMutableDictionary *sslProperties = [[[NSMutableDictionary alloc] initWithCapacity:1] autorelease];
+
         // Tell CFNetwork not to validate SSL certificates
         if (![self validatesSecureCertificate]) {
             // see: http://iphonedevelopment.blogspot.com/2010/05/nsstream-tcp-and-ssl.html
             
-            NSDictionary *sslProperties = [[NSDictionary alloc] initWithObjectsAndKeys:
+            sslProperties = [[[NSMutableDictionary alloc] initWithObjectsAndKeys:
                                       [NSNumber numberWithBool:YES], kCFStreamSSLAllowsExpiredCertificates,
                                       [NSNumber numberWithBool:YES], kCFStreamSSLAllowsAnyRoot,
                                       [NSNumber numberWithBool:NO],  kCFStreamSSLValidatesCertificateChain,
-                                      kCFNull,kCFStreamSSLPeerName,
-                                      nil];
-            
-            CFReadStreamSetProperty((CFReadStreamRef)[self readStream], 
-                                    kCFStreamPropertySSLSettings, 
-                                    (CFTypeRef)sslProperties);
+																					 kCFNull,kCFStreamSSLPeerName,
+                                      nil] autorelease];
+					
+					
         } 
         
         // Tell CFNetwork to use a client certificate
         if (clientCertificateIdentity) {
-            NSMutableDictionary *sslProperties = [NSMutableDictionary dictionaryWithCapacity:1];
             
-			NSMutableArray *certificates = [NSMutableArray arrayWithCapacity:[clientCertificates count]+1];
+					NSMutableArray *certificates = [NSMutableArray arrayWithCapacity:[clientCertificates count]+1];
 
-			// The first object in the array is our SecIdentityRef
-			[certificates addObject:(id)clientCertificateIdentity];
+					// The first object in the array is our SecIdentityRef
+					[certificates addObject:(id)clientCertificateIdentity];
 
-			// If we've added any additional certificates, add them too
-			for (id cert in clientCertificates) {
-				[certificates addObject:cert];
-			}
+					// If we've added any additional certificates, add them too
+					for (id cert in clientCertificates) {
+						[certificates addObject:cert];
+					}
+								
+								[sslProperties setObject:certificates forKey:(NSString *)kCFStreamSSLCertificates];
             
-            [sslProperties setObject:certificates forKey:(NSString *)kCFStreamSSLCertificates];
-            
-            CFReadStreamSetProperty((CFReadStreamRef)[self readStream], kCFStreamPropertySSLSettings, sslProperties);
         }
-        
+			CFReadStreamSetProperty((CFReadStreamRef)[self readStream], kCFStreamPropertySSLSettings,(CFTypeRef)sslProperties);
+			
     }
 
 	//


### PR DESCRIPTION
When using self-signed client certificates you need to set the SSL properties as well as setting the client certificate. Under iOS 5 the call to CFReadStreamSetProperty apparently overwrites the existing values (previously it seemed to add to them) - so the current code structure means setting the certificate looses the SSL properties. This fix allows them both to be set together.
