### PR TITLE
Fixed leaking sslProperties in startRequest. 

### DIFF
--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -1204,7 +1204,7 @@ static NSOperationQueue *sharedQueue = nil;
         if (![self validatesSecureCertificate]) {
             // see: http://iphonedevelopment.blogspot.com/2010/05/nsstream-tcp-and-ssl.html
             
-            NSDictionary *sslProperties = [[NSDictionary alloc] initWithObjectsAndKeys:
+            NSDictionary *sslProperties = [NSDictionary dictionaryWithObjectsAndKeys:
                                       [NSNumber numberWithBool:YES], kCFStreamSSLAllowsExpiredCertificates,
                                       [NSNumber numberWithBool:YES], kCFStreamSSLAllowsAnyRoot,
                                       [NSNumber numberWithBool:NO],  kCFStreamSSLValidatesCertificateChain,


### PR DESCRIPTION
My first pull request ever :-)
Changed sslProperties in startRequest to autoreleased dictionaryWithObjectsAndKeys to fix memory leak
I used dictionaryWithObjectsAndKeys instead of autorelease so there is one less thing to change when you transition to arc.
