### PR TITLE
Fixed bug preventing ASIAuthenticationDialog from being dismissed

### DIFF
--- a/Classes/ASIAuthenticationDialog.m
+++ b/Classes/ASIAuthenticationDialog.m
@@ -216,7 +216,10 @@ static const NSUInteger kDomainSection = 1;
 
 + (void)dismiss
 {
-	[[sharedDialog parentViewController] dismissModalViewControllerAnimated:YES];
+	if ([sharedDialog respondsToSelector:@selector(presentingViewController)])
+		[[sharedDialog presentingViewController] dismissModalViewControllerAnimated:YES];
+	else 
+		[[sharedDialog parentViewController] dismissModalViewControllerAnimated:YES];
 }
 
 - (void)viewDidDisappear:(BOOL)animated
@@ -233,7 +236,10 @@ static const NSUInteger kDomainSection = 1;
 	if (self == sharedDialog) {
 		[[self class] dismiss];
 	} else {
-		[[self parentViewController] dismissModalViewControllerAnimated:YES];
+		if ([self respondsToSelector:@selector(presentingViewController)])
+			[[self presentingViewController] dismissModalViewControllerAnimated:YES];
+		else
+			[[self parentViewController] dismissModalViewControllerAnimated:YES];
 	}
 }
 


### PR DESCRIPTION
In iOS 5, the ASIAuthenticationDialog could not be dismissed using either the Cancel button or automatically by successfully logging in.
The bug is due to a change in UIViewController in iOS 5.  The class & instance "dismiss" methods are using [UIViewController parentViewController] which, as of iOS 5, no longer returns the presenting view controller.  A new property called 'presentingViewController' was added in iOS 5 to make up for this.

Changed the class & instance dismiss methods to use the "presentingViewController" property if it is available (iOS 5+).  If not, it falls back to the "parentViewController" property.

This bug was previously reported in issue #277.  However, it was closed with no explanation by the user that created it.
