### PR TITLE
Redirect delegate call sequence fix

### DIFF
--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -1466,6 +1466,7 @@ static NSOperationQueue *sharedQueue = nil;
 	} else {
 		// Go all the way back to the beginning and build the request again, so that we can apply any new cookies
 		[self main];
+        [self performSelectorOnMainThread:@selector(requestRedirected) withObject:nil waitUntilDone:[NSThread isMainThread]];
 	}
 }
 
@@ -2313,8 +2314,6 @@ static NSOperationQueue *sharedQueue = nil;
 	if (responseCode != 301 && responseCode != 302 && responseCode != 303 && responseCode != 307) {
 		return NO;
 	}
-
-	[self performSelectorOnMainThread:@selector(requestRedirected) withObject:nil waitUntilDone:[NSThread isMainThread]];
 
 	// By default, we redirect 301 and 302 response codes as GET requests
 	// According to RFC 2616 this is wrong, but this is what most browsers do, so it's probably what you're expecting to happen


### PR DESCRIPTION
Currently, the `requestRedirected` delegate method will be called right after the header is parsed. However, the data received delegate method which comes together with the redirected header will be called **after** the `requestRedirected` callback. 

The sequence is like this:
1. HTTP Redirect Header
2. `requestRedirected`
3. HTTP Redirect Body (usually some simple html indicate the redirection)
4. `dataReceived`
5. HTTP Header
6. `headerReceived`
7. HTTP Body
8. `dataReceived`

I think in this sequence, step 4 may cause bugs. The delegate is most likely accumulating the received data for writing to file, live parsing, etc. Apparently, we should not append the data received from step 4 to step 8. The most straight forward thought is to "reset" the data status after the request being redirected but that actually happens before step 4.

I propose to move the step 2 between step 4 and 5.
