### PR TITLE
Add support for x-amz-security-token header

### DIFF
--- a/Classes/S3/ASIS3ObjectRequest.h
+++ b/Classes/S3/ASIS3ObjectRequest.h
@@ -39,6 +39,9 @@ extern NSString *const ASIS3StorageClassReducedRedundancy;
 	// Set this to ASIS3StorageClassReducedRedundancy to save money on storage, at (presumably) a slightly higher risk you will lose the data
 	// If this is not set, no x-amz-storage-class header will be sent to S3, and their default will be used
 	NSString *storageClass;
+    
+    // If this is not set, no x-amz-security-token header will be sent to S3, and their default will be used
+    NSString *securityToken;
 }
 
 // Create a request, building an appropriate url
@@ -77,4 +80,5 @@ extern NSString *const ASIS3StorageClassReducedRedundancy;
 @property (retain, nonatomic) NSString *mimeType;
 @property (retain, nonatomic) NSString *subResource;
 @property (retain, nonatomic) NSString *storageClass;
+@property (retain, nonatomic) NSString *securityToken;
 @end

--- a/Classes/S3/ASIS3ObjectRequest.m
+++ b/Classes/S3/ASIS3ObjectRequest.m
@@ -142,6 +142,9 @@ NSString *const ASIS3StorageClassReducedRedundancy = @"REDUCED_REDUNDANCY";
 	if ([self storageClass]) {
 		[headers setObject:[self storageClass] forKey:@"x-amz-storage-class"];
 	}
+    if ([self securityToken]) {
+        [headers setObject:[self securityToken] forKey:@"x-amz-security-token"];
+    }
 	return headers;
 }
 
@@ -161,4 +164,5 @@ NSString *const ASIS3StorageClassReducedRedundancy = @"REDUCED_REDUNDANCY";
 @synthesize mimeType;
 @synthesize subResource;
 @synthesize storageClass;
+@synthesize securityToken;
 @end


### PR DESCRIPTION
From Amazon Docs:
http://docs.amazonwebservices.com/AmazonS3/latest/dev/RESTAuthentication.html
### Using Temporary Security Credentials

If you are signing your request using temporary security credentials (see Making Requests), you must include the corresponding security token in your request by adding the x-amz-security-token header.
