### PR TITLE
Fix for self-signed client certificates on iOS 5 (alternate)

### DIFF
--- a/Classes/ASIHTTPRequest.h
+++ b/Classes/ASIHTTPRequest.h
@@ -368,8 +368,12 @@ typedef void (^ASIDataBlock)(NSData *data);
     
     // If not nil and the URL scheme is https, CFNetwork configured to supply a client certificate
     SecIdentityRef clientCertificateIdentity;
+
 	NSArray *clientCertificates;
 	
+    // If not nil and the URL scheme is https, CFNetwork configured to check server certificates with ONLY this CA certificate
+		SecCertificateRef caCertificate;
+
 	// Details on the proxy to use - you could set these yourself, but it's probably best to let ASIHTTPRequest detect the system proxy settings
 	NSString *proxyHost;
 	int proxyPort;
@@ -439,6 +443,9 @@ typedef void (^ASIDataBlock)(NSData *data);
 	
 	// Used internally to record when a request has finished downloading data
 	BOOL downloadComplete;
+	
+	// Used internally to record when a request has been checked against a ca certificate
+	BOOL caCertificateCheckComplete;
 	
 	// An ID that uniquely identifies this request - primarily used for debugging persistent connections
 	NSNumber *requestID;
@@ -754,6 +761,10 @@ typedef void (^ASIDataBlock)(NSData *data);
 #pragma mark client certificate
 
 - (void)setClientCertificateIdentity:(SecIdentityRef)anIdentity;
+
+#pragma mark ca certificate
+
+- (void)setCaCertificate:(SecCertificateRef)aCaCertificate;
 
 #pragma mark session credentials
 


### PR DESCRIPTION
1.) Restructure handling of ssl options (i.e., kCFStreamPropertySSLSettings) so that disabling SSL certificate verification and adding an SSL client certificate are not mutually exclusive. Also removed several settings which appear unneeded to successfully use a self-signed certificate / a certificate using a self generated CA based on my testing; further context on the necessity of these options (kCFStreamSSLAllowsExpiredCertificates, kCFStreamSSLAllowsAnyRoot, setting kCFStreamSSLPeerName to kCFNull) would be useful.

2.) Add option to specify an SSL CA Certificate to use instead of the normal root certificates for verifying a server certificate. Note that this isn't handled in an ideal fashion - certificate verification is completely disabled for the initial handshake, then manually checked on the first read event (i.e., when handleNetworkEvent gets a kCFStreamEventHasBytesAvailable event). I was unable to succeed at other methods of adding a root CA certificate (adding it to the keychain, altering the ssl context)

FYI, this is my first time using github/submitting, so feedback is welcome.
