### PR TITLE
Patch to fix a problem when using didReceiveData: delegate or dataReceivedBlock callback

### DIFF
--- a/Classes/ASIHTTPRequest.h
+++ b/Classes/ASIHTTPRequest.h
@@ -193,7 +193,7 @@ typedef void (^ASIDataBlock)(NSData *data);
 	NSString *password;
 	
 	// User-Agent for this request
-	NSString *userAgent;
+	NSString *userAgentString;
 	
 	// Domain used for NTLM authentication
 	NSString *domain;
@@ -903,7 +903,7 @@ typedef void (^ASIDataBlock)(NSData *data);
 
 @property (retain) NSString *username;
 @property (retain) NSString *password;
-@property (retain) NSString *userAgent;
+@property (retain) NSString *userAgentString;
 @property (retain) NSString *domain;
 
 @property (retain) NSString *proxyUsername;

--- a/Classes/ASIHTTPRequest.h
+++ b/Classes/ASIHTTPRequest.h
@@ -264,6 +264,9 @@ typedef void (^ASIDataBlock)(NSData *data);
 	// Description of the HTTP status code
 	NSString *responseStatusMessage;
 	
+    // HTTP version of the response
+    NSString *responseVersion;
+    
 	// Size of the response
 	unsigned long long contentLength;
 	
@@ -944,6 +947,7 @@ typedef void (^ASIDataBlock)(NSData *data);
 @property (retain) NSDictionary *proxyCredentials;
 @property (assign,readonly) int responseStatusCode;
 @property (retain,readonly) NSString *responseStatusMessage;
+@property (retain,readonly) NSString *responseVersion;
 @property (retain) NSMutableData *rawResponseData;
 @property (assign) NSTimeInterval timeOutSeconds;
 @property (retain, nonatomic) NSString *requestMethod;

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -392,7 +392,7 @@ static NSOperationQueue *sharedQueue = nil;
 	[connectionInfo release];
 	[requestID release];
 	[dataDecompressor release];
-	[userAgent release];
+	[userAgentString release];
 
 	#if NS_BLOCKS_AVAILABLE
 	[self releaseBlocksOnMainThread];
@@ -1088,12 +1088,12 @@ static NSOperationQueue *sharedQueue = nil;
 	
 	// Build and set the user agent string if the request does not already have a custom user agent specified
 	if (![[self requestHeaders] objectForKey:@"User-Agent"]) {
-		NSString *userAgentString = [self userAgent];
-		if (!userAgentString) {
-			userAgentString = [ASIHTTPRequest defaultUserAgentString];
+		NSString *tempUserAgentString = [self userAgentString];
+		if (!tempUserAgentString) {
+			tempUserAgentString = [ASIHTTPRequest defaultUserAgentString];
 		}
-		if (userAgentString) {
-			[self addRequestHeader:@"User-Agent" value:userAgentString];
+		if (tempUserAgentString) {
+			[self addRequestHeader:@"User-Agent" value:tempUserAgentString];
 		}
 	}
 	
@@ -4999,7 +4999,7 @@ static NSOperationQueue *sharedQueue = nil;
 
 @synthesize username;
 @synthesize password;
-@synthesize userAgent;
+@synthesize userAgentString;
 @synthesize domain;
 @synthesize proxyUsername;
 @synthesize proxyPassword;

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -3331,6 +3331,12 @@ static NSOperationQueue *sharedQueue = nil;
 			dataWillBeHandledExternally = YES;
 		}
 		#endif
+        
+		if ([self authenticationNeeded]) {
+			// Don't pass the body of a 401/407 response to the callback.
+			dataWillBeHandledExternally = NO;
+		}
+        
 		// Does the delegate want to handle the data manually?
 		if (dataWillBeHandledExternally) {
 

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -225,6 +225,7 @@ static NSOperationQueue *sharedQueue = nil;
 @property (retain) NSString *authenticationRealm;
 @property (retain) NSString *proxyAuthenticationRealm;
 @property (retain) NSString *responseStatusMessage;
+@property (retain) NSString *responseVersion;
 @property (assign) BOOL inProgress;
 @property (assign) int retryCount;
 @property (assign) BOOL willRetryRequest;
@@ -389,6 +390,7 @@ static NSOperationQueue *sharedQueue = nil;
 	[PACurl release];
 	[clientCertificates release];
 	[responseStatusMessage release];
+	[responseVersion release];
 	[connectionInfo release];
 	[requestID release];
 	[dataDecompressor release];
@@ -2155,6 +2157,7 @@ static NSOperationQueue *sharedQueue = nil;
 	[self setResponseHeaders:[NSMakeCollectable(CFHTTPMessageCopyAllHeaderFields(message)) autorelease]];
 	[self setResponseStatusCode:(int)CFHTTPMessageGetResponseStatusCode(message)];
 	[self setResponseStatusMessage:[NSMakeCollectable(CFHTTPMessageCopyResponseStatusLine(message)) autorelease]];
+    [self setResponseVersion:[NSMakeCollectable(CFHTTPMessageCopyVersion(message)) autorelease]];
 
 	if ([self downloadCache] && ([[self downloadCache] canUseCachedDataForRequest:self])) {
 
@@ -2258,10 +2261,8 @@ static NSOperationQueue *sharedQueue = nil;
 		
 		NSString *connectionHeader = [[[self responseHeaders] objectForKey:@"Connection"] lowercaseString];
 
-		NSString *httpVersion = [NSMakeCollectable(CFHTTPMessageCopyVersion(message)) autorelease];
-		
 		// Don't re-use the connection if the server is HTTP 1.0 and didn't send Connection: Keep-Alive
-		if (![httpVersion isEqualToString:(NSString *)kCFHTTPVersion1_0] || [connectionHeader isEqualToString:@"keep-alive"]) {
+		if (![self.responseVersion isEqualToString:(NSString *)kCFHTTPVersion1_0] || [connectionHeader isEqualToString:@"keep-alive"]) {
 
 			// See if server explicitly told us to close the connection
 			if (![connectionHeader isEqualToString:@"close"]) {
@@ -5092,6 +5093,7 @@ static NSOperationQueue *sharedQueue = nil;
 @synthesize shouldPresentProxyAuthenticationDialog;
 @synthesize authenticationNeeded;
 @synthesize responseStatusMessage;
+@synthesize responseVersion;
 @synthesize shouldPresentCredentialsBeforeChallenge;
 @synthesize haveBuiltRequestHeaders;
 @synthesize inProgress;

--- a/Classes/Tests/ASIHTTPRequestTests.m
+++ b/Classes/Tests/ASIHTTPRequestTests.m
@@ -400,7 +400,7 @@
 
 	// Test again using userAgent
 	request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:@"http://allseeing-i.com/ASIHTTPRequest/tests/user-agent"]];
-	[request setUserAgent:customUserAgent];
+	[request setUserAgentString:customUserAgent];
 	[request startSynchronous];
 	success = [[request responseString] isEqualToString:customUserAgent];
 	GHAssertTrue(success,@"Failed to set the correct user-agent for a single request");


### PR DESCRIPTION
There is a problem when processing data using callbacks/delegates whereby the callback receives the body of a 401/407 response, and there is no way to tell from the callback whether the data is from the initial 40x response or from a subsequent response.  This means if you are using a streaming parser with ASIHTTPRequest, you will get garbage before the actual data.

You cannot check the response status code, response headers, or any other part of the request inside the block because the values may have changed between the time the data was received and when the callback happens.  The passOnReceivedData callback is enqueued on the main thread and execution is not blocked, so the callback can happen much later, after the request has successfully retried and looks like it was successful.

My patch simply disables the data callbacks when authentication is needed, so the 40x response is simply added to the rawResponseData buffer as it would be if there were no callbacks defined.  Considering it is not possible with the current interface to figure out which request the data came from, the code as it stands is not useful anyway.  With the patch, you can still get the 40x body through the standard interfaces if you need to access it.

I think this approach is better than changing the callback interface to include additional information like response status code, etc.
