### PR TITLE
Use recursive bandwidth throttling lock to avoid deadlock. Fixes issue #239

### DIFF
--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -89,7 +89,7 @@ static unsigned long bandwidthUsedInLastSecond = 0;
 static NSDate *bandwidthMeasurementDate = nil;
 
 // Since throttling variables are shared among all requests, we'll use a lock to mediate access
-static NSLock *bandwidthThrottlingLock = nil;
+static NSRecursiveLock *bandwidthThrottlingLock = nil;
 
 // the maximum number of bytes that can be transmitted in one second
 static unsigned long maxBandwidthPerSecond = 0;
@@ -259,7 +259,7 @@ static NSOperationQueue *sharedQueue = nil;
 		persistentConnectionsPool = [[NSMutableArray alloc] init];
 		connectionsLock = [[NSRecursiveLock alloc] init];
 		progressLock = [[NSRecursiveLock alloc] init];
-		bandwidthThrottlingLock = [[NSLock alloc] init];
+		bandwidthThrottlingLock = [[NSRecursiveLock alloc] init];
 		sessionCookiesLock = [[NSRecursiveLock alloc] init];
 		sessionCredentialsLock = [[NSRecursiveLock alloc] init];
 		delegateAuthenticationLock = [[NSRecursiveLock alloc] init];


### PR DESCRIPTION
Seems to fix #239. It's a hard bug to reproduce, I've uploaded about 9000 files over 4 hours and then it deadlocked.
