### PR TITLE
Add support for Amazon S3's server-side encryption

### DIFF
--- a/Classes/S3/ASIS3ObjectRequest.h
+++ b/Classes/S3/ASIS3ObjectRequest.h
@@ -77,4 +77,5 @@ extern NSString *const ASIS3StorageClassReducedRedundancy;
 @property (retain, nonatomic) NSString *mimeType;
 @property (retain, nonatomic) NSString *subResource;
 @property (retain, nonatomic) NSString *storageClass;
+@property (assign, nonatomic) BOOL useServerSideEncryption;
 @end

--- a/Classes/S3/ASIS3ObjectRequest.m
+++ b/Classes/S3/ASIS3ObjectRequest.m
@@ -142,6 +142,9 @@ NSString *const ASIS3StorageClassReducedRedundancy = @"REDUCED_REDUNDANCY";
 	if ([self storageClass]) {
 		[headers setObject:[self storageClass] forKey:@"x-amz-storage-class"];
 	}
+	if ([self useServerSideEncryption]) {
+		[headers setObject:@"AES256" forKey:@"x-amz-server-side-encryption"];
+	}
 	return headers;
 }
 
@@ -161,4 +164,5 @@ NSString *const ASIS3StorageClassReducedRedundancy = @"REDUCED_REDUNDANCY";
 @synthesize mimeType;
 @synthesize subResource;
 @synthesize storageClass;
+@synthesize useServerSideEncryption;
 @end


### PR DESCRIPTION
Adds a property to `ASIS3ObjectRequest` to instruct Amazon S3 to store the objected encrypted, [as described here](http://aws.typepad.com/aws/2011/10/new-amazon-s3-server-side-encryption.html).

``` objective-c
ASIS3ObjectRequest *request = 
 [ASIS3ObjectRequest PUTRequestForFile:filePath withBucket:@"my-bucket" key:@"path/to/the/object"];
[request setUseServerSideEncryption:YES]; // <-- use SSE
[request startSynchronous];
if ([request error]) {
   NSLog(@"%@",[[request error] localizedDescription]);
}
```
