### PR TITLE
Adding response HTTP Version accessors to Request object

### DIFF
--- a/Classes/ASIHTTPRequest.h
+++ b/Classes/ASIHTTPRequest.h
@@ -260,9 +260,12 @@ typedef void (^ASIDataBlock)(NSData *data);
 	
 	// HTTP status code, eg: 200 = OK, 404 = Not found etc
 	int responseStatusCode;
-	
+
 	// Description of the HTTP status code
 	NSString *responseStatusMessage;
+
+	// HTTP Version, e.g. 1.0, 1.1 etc
+	NSString *responseHTTPVersion;
 	
 	// Size of the response
 	unsigned long long contentLength;
@@ -944,6 +947,7 @@ typedef void (^ASIDataBlock)(NSData *data);
 @property (retain) NSDictionary *proxyCredentials;
 @property (assign,readonly) int responseStatusCode;
 @property (retain,readonly) NSString *responseStatusMessage;
+@property (retain,readonly) NSString *responseHTTPVersion;
 @property (retain) NSMutableData *rawResponseData;
 @property (assign) NSTimeInterval timeOutSeconds;
 @property (retain, nonatomic) NSString *requestMethod;

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -24,7 +24,7 @@
 #import "ASIDataCompressor.h"
 
 // Automatically set on build
-NSString *ASIHTTPRequestVersion = @"v1.8.1-61 2011-09-19";
+NSString *ASIHTTPRequestVersion = @"v1.8.1-79 2012-05-31";
 
 static NSString *defaultUserAgent = nil;
 
@@ -225,6 +225,7 @@ static NSOperationQueue *sharedQueue = nil;
 @property (retain) NSString *authenticationRealm;
 @property (retain) NSString *proxyAuthenticationRealm;
 @property (retain) NSString *responseStatusMessage;
+@property (retain) NSString *responseHTTPVersion;
 @property (assign) BOOL inProgress;
 @property (assign) int retryCount;
 @property (assign) BOOL willRetryRequest;
@@ -389,6 +390,7 @@ static NSOperationQueue *sharedQueue = nil;
 	[PACurl release];
 	[clientCertificates release];
 	[responseStatusMessage release];
+	[responseHTTPVersion release];
 	[connectionInfo release];
 	[requestID release];
 	[dataDecompressor release];
@@ -2155,6 +2157,7 @@ static NSOperationQueue *sharedQueue = nil;
 	[self setResponseHeaders:[NSMakeCollectable(CFHTTPMessageCopyAllHeaderFields(message)) autorelease]];
 	[self setResponseStatusCode:(int)CFHTTPMessageGetResponseStatusCode(message)];
 	[self setResponseStatusMessage:[NSMakeCollectable(CFHTTPMessageCopyResponseStatusLine(message)) autorelease]];
+	[self setResponseHTTPVersion:[NSMakeCollectable(CFHTTPMessageCopyVersion(message)) autorelease]];
 
 	if ([self downloadCache] && ([[self downloadCache] canUseCachedDataForRequest:self])) {
 
@@ -5086,6 +5089,7 @@ static NSOperationQueue *sharedQueue = nil;
 @synthesize shouldPresentProxyAuthenticationDialog;
 @synthesize authenticationNeeded;
 @synthesize responseStatusMessage;
+@synthesize responseHTTPVersion;
 @synthesize shouldPresentCredentialsBeforeChallenge;
 @synthesize haveBuiltRequestHeaders;
 @synthesize inProgress;


### PR DESCRIPTION
Using the same CF CFHTTPMessageCopyVersion call. This is in line with the other calls being used such as CFHTTPMessageCopyResponseStatusLine and CFHTTPMessageGetResponseStatusCode.
