### PR TITLE
HTTP Status Code Overwrite Fix

### DIFF
--- a/Classes/ASIHTTPRequest.h
+++ b/Classes/ASIHTTPRequest.h
@@ -261,6 +261,10 @@ typedef void (^ASIDataBlock)(NSData *data);
 	// HTTP status code, eg: 200 = OK, 404 = Not found etc
 	int responseStatusCode;
 	
+	// HTTP status code, eg: 200 = OK, 404 = Not found etc. 
+	// This does NOT change unlike responseStatusCode when cached headers are pulled from disk.
+	int uncachedResponseStatusCode;
+
 	// Description of the HTTP status code
 	NSString *responseStatusMessage;
 	
@@ -943,6 +947,7 @@ typedef void (^ASIDataBlock)(NSData *data);
 @property (retain) NSDictionary *requestCredentials;
 @property (retain) NSDictionary *proxyCredentials;
 @property (assign,readonly) int responseStatusCode;
+@property (assign,readonly) int uncachedResponseStatusCode;
 @property (retain,readonly) NSString *responseStatusMessage;
 @property (retain) NSMutableData *rawResponseData;
 @property (assign) NSTimeInterval timeOutSeconds;

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -204,6 +204,7 @@ static NSOperationQueue *sharedQueue = nil;
 @property (assign) BOOL complete;
 @property (retain) NSArray *responseCookies;
 @property (assign) int responseStatusCode;
+@property (assign) int uncachedResponseStatusCode;
 @property (retain, nonatomic) NSDate *lastActivityTime;
 
 @property (assign) unsigned long long partialDownloadSize;
@@ -2154,6 +2155,7 @@ static NSOperationQueue *sharedQueue = nil;
 
 	[self setResponseHeaders:[NSMakeCollectable(CFHTTPMessageCopyAllHeaderFields(message)) autorelease]];
 	[self setResponseStatusCode:(int)CFHTTPMessageGetResponseStatusCode(message)];
+	[self setUncachedResponseStatusCode:(int)CFHTTPMessageGetResponseStatusCode(message)];
 	[self setResponseStatusMessage:[NSMakeCollectable(CFHTTPMessageCopyResponseStatusLine(message)) autorelease]];
 
 	if ([self downloadCache] && ([[self downloadCache] canUseCachedDataForRequest:self])) {
@@ -5032,6 +5034,7 @@ static NSOperationQueue *sharedQueue = nil;
 @synthesize requestCookies;
 @synthesize requestCredentials;
 @synthesize responseStatusCode;
+@synthesize uncachedResponseStatusCode;
 @synthesize rawResponseData;
 @synthesize lastActivityTime;
 @synthesize timeOutSeconds;


### PR DESCRIPTION
ASIDownloadCache will rewrite responseStatusCode with cached headers,
thus making it impossible to see what the status code was of the actual request.
