### PR TITLE
Fixed 6 warnings in xcode 4.3.3 and 4.5

### DIFF
--- a/Classes/ASIDataCompressor.m
+++ b/Classes/ASIDataCompressor.m
@@ -212,7 +212,7 @@
 
 + (NSError *)deflateErrorWithCode:(int)code
 {
-	return [NSError errorWithDomain:NetworkRequestErrorDomain code:ASICompressionError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Compression of data failed with code %hi",code],NSLocalizedDescriptionKey,nil]];
+	return [NSError errorWithDomain:NetworkRequestErrorDomain code:ASICompressionError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Compression of data failed with code %hi",code],(short)NSLocalizedDescriptionKey,nil]];
 }
 
 @synthesize streamReady;

--- a/Classes/ASIDataDecompressor.m
+++ b/Classes/ASIDataDecompressor.m
@@ -211,7 +211,7 @@
 
 + (NSError *)inflateErrorWithCode:(int)code
 {
-	return [NSError errorWithDomain:NetworkRequestErrorDomain code:ASICompressionError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Decompression of data failed with code %hi",code],NSLocalizedDescriptionKey,nil]];
+	return [NSError errorWithDomain:NetworkRequestErrorDomain code:ASICompressionError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Decompression of data failed with code %hi",code],(short)NSLocalizedDescriptionKey,nil]];
 }
 
 @synthesize streamReady;

--- a/Classes/S3/ASIS3BucketRequest.m
+++ b/Classes/S3/ASIS3BucketRequest.m
@@ -98,7 +98,7 @@
 		[queryParts addObject:[NSString stringWithFormat:@"delimiter=%@",[[self delimiter] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]]];
 	}
 	if ([self maxResultCount] > 0) {
-		[queryParts addObject:[NSString stringWithFormat:@"max-keys=%hi",[self maxResultCount]]];
+		[queryParts addObject:[NSString stringWithFormat:@"max-keys=%hi",(short)[self maxResultCount]]];
 	}
 	if ([queryParts count]) {
 		NSString* template = @"%@?%@";

--- a/External/Reachability/Reachability.m
+++ b/External/Reachability/Reachability.m
@@ -161,13 +161,13 @@ static void logNetworkStatus_(const char *name, int line, NetworkStatus status) 
 	
 	switch (status) {
 		case kNotReachable:
-			statusString = [NSString stringWithString: @"Not Reachable"];
+			statusString = @"Not Reachable";
 			break;
 		case kReachableViaWWAN:
-			statusString = [NSString stringWithString: @"Reachable via WWAN"];
+			statusString = @"Reachable via WWAN";
 			break;
 		case kReachableViaWiFi:
-			statusString = [NSString stringWithString: @"Reachable via WiFi"];
+			statusString = @"Reachable via WiFi";
 			break;
 	}
 	


### PR DESCRIPTION
in xCode 4.3.3, it regards [NSString stringWithString@"somestr"] and format %hi with an int number as warnings. This commit fixed these issues.
