### PR TITLE
Extended ASIBasicBlock to include reference to the owning request

### DIFF
--- a/Classes/ASIHTTPRequest.h
+++ b/Classes/ASIHTTPRequest.h
@@ -74,7 +74,7 @@ extern NSString* const NetworkRequestErrorDomain;
 extern unsigned long const ASIWWANBandwidthThrottleAmount;
 
 #if NS_BLOCKS_AVAILABLE
-typedef void (^ASIBasicBlock)(void);
+typedef void (^ASIBasicBlock)(ASIHTTPRequest* request);
 typedef void (^ASIHeadersBlock)(NSDictionary *responseHeaders);
 typedef void (^ASISizeBlock)(long long size);
 typedef void (^ASIProgressBlock)(unsigned long long size, unsigned long long total);

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -1742,7 +1742,7 @@ static NSOperationQueue *sharedQueue = nil;
 	#if NS_BLOCKS_AVAILABLE
     if (bytesReceivedBlock) {
 		unsigned long long totalSize = [self contentLength] + [self partialDownloadSize];
-		[self performBlockOnMainThread:^{ if (bytesReceivedBlock) { bytesReceivedBlock(value, totalSize); }}];
+		[self performBlockOnMainThread:^(ASIHTTPRequest* request){ if (bytesReceivedBlock) { bytesReceivedBlock(value, totalSize); }}];
     }
 	#endif
 	[self setLastBytesRead:bytesReadSoFar];
@@ -1786,7 +1786,7 @@ static NSOperationQueue *sharedQueue = nil;
 	#if NS_BLOCKS_AVAILABLE
     if(bytesSentBlock){
 		unsigned long long totalSize = [self postLength];
-		[self performBlockOnMainThread:^{ if (bytesSentBlock) { bytesSentBlock(value, totalSize); }}];
+		[self performBlockOnMainThread:^(ASIHTTPRequest* request){ if (bytesSentBlock) { bytesSentBlock(value, totalSize); }}];
 	}
 	#endif
 }
@@ -1799,7 +1799,7 @@ static NSOperationQueue *sharedQueue = nil;
 
 	#if NS_BLOCKS_AVAILABLE
     if(downloadSizeIncrementedBlock){
-		[self performBlockOnMainThread:^{ if (downloadSizeIncrementedBlock) { downloadSizeIncrementedBlock(length); }}];
+		[self performBlockOnMainThread:^(ASIHTTPRequest* request){ if (downloadSizeIncrementedBlock) { downloadSizeIncrementedBlock(length); }}];
     }
 	#endif
 }
@@ -1811,7 +1811,7 @@ static NSOperationQueue *sharedQueue = nil;
 
 	#if NS_BLOCKS_AVAILABLE
     if(uploadSizeIncrementedBlock) {
-		[self performBlockOnMainThread:^{ if (uploadSizeIncrementedBlock) { uploadSizeIncrementedBlock(length); }}];
+		[self performBlockOnMainThread:^(ASIHTTPRequest* request){ if (uploadSizeIncrementedBlock) { uploadSizeIncrementedBlock(length); }}];
     }
 	#endif
 }
@@ -1827,7 +1827,7 @@ static NSOperationQueue *sharedQueue = nil;
 	#if NS_BLOCKS_AVAILABLE
     if(bytesSentBlock){
 		unsigned long long totalSize = [self postLength];
-		[self performBlockOnMainThread:^{  if (bytesSentBlock) { bytesSentBlock(progressToRemove, totalSize); }}];
+		[self performBlockOnMainThread:^(ASIHTTPRequest* request){  if (bytesSentBlock) { bytesSentBlock(progressToRemove, totalSize); }}];
 	}
 	#endif
 }
@@ -1840,7 +1840,7 @@ static NSOperationQueue *sharedQueue = nil;
 
 - (void)callBlock:(ASIBasicBlock)block
 {
-	block();
+	block(self);
 }
 #endif
 
@@ -1937,7 +1937,7 @@ static NSOperationQueue *sharedQueue = nil;
 	}
 	#if NS_BLOCKS_AVAILABLE
 	if(startedBlock){
-		startedBlock();
+		startedBlock(self);
 	}
 	#endif
 	if (queue && [queue respondsToSelector:@selector(requestStarted:)]) {
@@ -1958,7 +1958,7 @@ static NSOperationQueue *sharedQueue = nil;
 
 	#if NS_BLOCKS_AVAILABLE
 	if(requestRedirectedBlock){
-		requestRedirectedBlock();
+		requestRedirectedBlock(self);
 	}
 	#endif
 }
@@ -2026,7 +2026,7 @@ static NSOperationQueue *sharedQueue = nil;
 
 	#if NS_BLOCKS_AVAILABLE
 	if(completionBlock){
-		completionBlock();
+		completionBlock(self);
 	}
 	#endif
 
@@ -2044,7 +2044,7 @@ static NSOperationQueue *sharedQueue = nil;
 
 	#if NS_BLOCKS_AVAILABLE
     if(failureBlock){
-        failureBlock();
+        failureBlock(self);
     }
 	#endif
 
@@ -2700,7 +2700,7 @@ static NSOperationQueue *sharedQueue = nil;
 	}
 	#if NS_BLOCKS_AVAILABLE
 	if(proxyAuthenticationNeededBlock){
-		proxyAuthenticationNeededBlock();
+		proxyAuthenticationNeededBlock(self);
 	}
 	#endif
 }
@@ -2752,7 +2752,7 @@ static NSOperationQueue *sharedQueue = nil;
 	
 	#if NS_BLOCKS_AVAILABLE
 	if (authenticationNeededBlock) {
-		authenticationNeededBlock();
+		authenticationNeededBlock(self);
 	}
 	#endif	
 }

--- a/Classes/Tests/BlocksTests.m
+++ b/Classes/Tests/BlocksTests.m
@@ -45,16 +45,16 @@
 	
 	// There's actually no need for us to use '__block' here, because we aren't using the request inside any of our blocks, but it's good to get into the habit of doing this anyway.
 	__block ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:@"http://allseeing-i.com/ASIHTTPRequest/tests/blocks"]];
-	[request setStartedBlock:^{
+	[request setStartedBlock:^(ASIHTTPRequest* request){
 		started = YES;
 	}];
 	[request setHeadersReceivedBlock:^(NSDictionary *headers) {
 		receivedHeaders = YES;
 	}];
-	[request setCompletionBlock:^{
+	[request setCompletionBlock:^(ASIHTTPRequest* request){
 		complete = YES;
 	}];
-	[request setFailedBlock:^{
+	[request setFailedBlock:^(ASIHTTPRequest* request){
 		failed = YES;
 	}];
 	[request setBytesReceivedBlock:^(unsigned long long length, unsigned long long total) {
@@ -94,7 +94,7 @@
 	
 	
 	request = [ASIHTTPRequest requestWithURL:nil];
-	[request setFailedBlock:^{
+	[request setFailedBlock:^(ASIHTTPRequest* request){
 		failed = YES;
 	}];
 	[request startSynchronous];

--- a/iPhone.xcodeproj/project.pbxproj
+++ b/iPhone.xcodeproj/project.pbxproj
@@ -687,7 +687,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "./Build\\ Scripts/set_version_number.rb\n./Build\\ Scripts/fetch_ios_ghunit.rb";
+			shellScript = "";
 		};
 		B52D492810DA4041008E8365 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -700,7 +700,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "./Build\\ Scripts/set_version_number.rb";
+			shellScript = "";
 		};
 		B576D71F11C7F34D0059B815 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Extended the ASIBasicBlock to pass a reference to the request to be
used during handling of the request (say for data) for those using ARC
who don't wish to explicitly create a weak reference to the request
object.
