### PR TITLE
Minor fixes for warnings reported by static analyzer

### DIFF
--- a/Classes/ASIDataCompressor.m
+++ b/Classes/ASIDataCompressor.m
@@ -212,7 +212,7 @@
 
 + (NSError *)deflateErrorWithCode:(int)code
 {
-	return [NSError errorWithDomain:NetworkRequestErrorDomain code:ASICompressionError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Compression of data failed with code %hi",code],NSLocalizedDescriptionKey,nil]];
+	return [NSError errorWithDomain:NetworkRequestErrorDomain code:ASICompressionError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Compression of data failed with code %d",code],NSLocalizedDescriptionKey,nil]];
 }
 
 @synthesize streamReady;

--- a/Classes/ASIDataDecompressor.m
+++ b/Classes/ASIDataDecompressor.m
@@ -211,7 +211,7 @@
 
 + (NSError *)inflateErrorWithCode:(int)code
 {
-	return [NSError errorWithDomain:NetworkRequestErrorDomain code:ASICompressionError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Decompression of data failed with code %hi",code],NSLocalizedDescriptionKey,nil]];
+	return [NSError errorWithDomain:NetworkRequestErrorDomain code:ASICompressionError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Decompression of data failed with code %d",code],NSLocalizedDescriptionKey,nil]];
 }
 
 @synthesize streamReady;

--- a/iPhone Sample/UploadViewController.m
+++ b/iPhone Sample/UploadViewController.m
@@ -43,7 +43,7 @@
 	//Add the file 8 times to the request, for a total request size around 2MB
 	int i;
 	for (i=0; i<8; i++) {
-		[request setFile:path forKey:[NSString stringWithFormat:@"file-%hi",i]];
+		[request setFile:path forKey:[NSString stringWithFormat:@"file-%i",i]];
 	}
 	
 	[request startAsynchronous];


### PR DESCRIPTION
The static analyzer in Xcode 4.4 reported some new issues. It's mostly some format specifiers which I've adjusted here.
