### PR TITLE
avoid overriding of the property kCFStreamPropertySSLSettings

### DIFF
--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -1205,44 +1205,43 @@ static NSOperationQueue *sharedQueue = nil;
     // Handle SSL certificate settings
     //
 
-    if([[[[self url] scheme] lowercaseString] isEqualToString:@"https"]) {       
+    if([[[[self url] scheme] lowercaseString] isEqualToString:@"https"]) {
+        
+        // Properties for the SSL connection
+        NSMutableDictionary *sslProperties = [NSMutableDictionary dictionary];
+        
+        // Tell CFNetwork to use a client certificate
+        if (clientCertificateIdentity) {
+            NSMutableArray *certificates = [NSMutableArray arrayWithCapacity:[clientCertificates count]+1];
+            
+            // The first object in the array is our SecIdentityRef
+            [certificates addObject:(id)clientCertificateIdentity];
+            
+            // If we've added any additional certificates, add them too
+            for (id cert in clientCertificates) {
+                [certificates addObject:cert];
+            }
+            
+            [sslProperties setObject:certificates forKey:(NSString *)kCFStreamSSLCertificates];
+        }
        
         // Tell CFNetwork not to validate SSL certificates
         if (![self validatesSecureCertificate]) {
             // see: http://iphonedevelopment.blogspot.com/2010/05/nsstream-tcp-and-ssl.html
             
-            NSDictionary *sslProperties = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                      [NSNumber numberWithBool:YES], kCFStreamSSLAllowsExpiredCertificates,
-                                      [NSNumber numberWithBool:YES], kCFStreamSSLAllowsAnyRoot,
-                                      [NSNumber numberWithBool:NO],  kCFStreamSSLValidatesCertificateChain,
-                                      kCFNull,kCFStreamSSLPeerName,
-                                      nil];
+            NSMutableDictionary *sslNotValidateCertificate = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
+                                                              [NSNumber numberWithBool:YES], kCFStreamSSLAllowsExpiredCertificates,
+                                                              [NSNumber numberWithBool:YES], kCFStreamSSLAllowsAnyRoot,
+                                                              [NSNumber numberWithBool:NO],  kCFStreamSSLValidatesCertificateChain,
+                                                              kCFNull,kCFStreamSSLPeerName,
+                                                              nil];
             
-            CFReadStreamSetProperty((CFReadStreamRef)[self readStream], 
-                                    kCFStreamPropertySSLSettings, 
-                                    (CFTypeRef)sslProperties);
-            [sslProperties release];
-        } 
-        
-        // Tell CFNetwork to use a client certificate
-        if (clientCertificateIdentity) {
-            NSMutableDictionary *sslProperties = [NSMutableDictionary dictionaryWithCapacity:1];
-            
-			NSMutableArray *certificates = [NSMutableArray arrayWithCapacity:[clientCertificates count]+1];
-
-			// The first object in the array is our SecIdentityRef
-			[certificates addObject:(id)clientCertificateIdentity];
-
-			// If we've added any additional certificates, add them too
-			for (id cert in clientCertificates) {
-				[certificates addObject:cert];
-			}
-            
-            [sslProperties setObject:certificates forKey:(NSString *)kCFStreamSSLCertificates];
-            
-            CFReadStreamSetProperty((CFReadStreamRef)[self readStream], kCFStreamPropertySSLSettings, sslProperties);
+            [sslProperties addEntriesFromDictionary:sslNotValidateCertificate];
+            [sslNotValidateCertificate release];
         }
         
+        // Set the properties
+        CFReadStreamSetProperty((CFReadStreamRef)[self readStream], kCFStreamPropertySSLSettings, sslProperties);
     }
 
 	//


### PR DESCRIPTION
the call to the function

CFReadStreamSetProperty((CFReadStreamRef)[self readStream], kCFStreamPropertySSLSettings, sslProperties);

to set the client certificate was overriding the previous values of the property kCFStreamPropertySSLSettings set to ignore certificates validation
