### PR TITLE
Fixing very obvious wrong behaviour when cleaning up the blocks that could cause many different-hard to figure out crashes

### DIFF
--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -404,7 +404,7 @@ static NSOperationQueue *sharedQueue = nil;
 #if NS_BLOCKS_AVAILABLE
 - (void)releaseBlocksOnMainThread
 {
-	NSMutableArray *blocks = [NSMutableArray array];
+	NSMutableArray *blocks = [[NSMutableArray alloc] init];
 	if (completionBlock) {
 		[blocks addObject:completionBlock];
 		[completionBlock release];
@@ -471,6 +471,7 @@ static NSOperationQueue *sharedQueue = nil;
 + (void)releaseBlocks:(NSArray *)blocks
 {
 	// Blocks will be released when this method exits
+	[blocks release];
 }
 #endif
 


### PR DESCRIPTION
There was a code added to make sure that the blocks were deallocated on the main thread, and it was wrong (it was over-releasing an NSMutableArray). Somebody fixed it by removing the second release, which is the wrong fix. There's an obvious code smell seeing how there's a performSelector: to a method that does nothing....
This is one of the thounsands of wrong things in ASIHTTPRequest, specially in memory management, I strongly recomment to all the folks out there that you migrate to [AFNetworking](https://github.com/AFNetworking/AFNetworking), but I'm pushing the pull request in case somebody is getting crashes from this.
