### PR TITLE
Significant performance enhancement for ASIDownloadCache's -clearCachedResponsesForStoragePolicy:

### DIFF
--- a/Classes/ASIAuthenticationDialog.m
+++ b/Classes/ASIAuthenticationDialog.m
@@ -217,9 +217,9 @@ static const NSUInteger kDomainSection = 1;
 + (void)dismiss
 {
 	if ([sharedDialog respondsToSelector:@selector(presentingViewController)])
-		[[sharedDialog presentingViewController] dismissModalViewControllerAnimated:YES];
+		[[sharedDialog presentingViewController] dismissViewControllerAnimated:YES completion:^{}];
 	else 
-		[[sharedDialog parentViewController] dismissModalViewControllerAnimated:YES];
+		[[sharedDialog parentViewController] dismissViewControllerAnimated:YES completion:^{}];
 }
 
 - (void)viewDidDisappear:(BOOL)animated
@@ -237,9 +237,9 @@ static const NSUInteger kDomainSection = 1;
 		[[self class] dismiss];
 	} else {
 		if ([self respondsToSelector:@selector(presentingViewController)])
-			[[self presentingViewController] dismissModalViewControllerAnimated:YES];
+			[[self presentingViewController] dismissViewControllerAnimated:YES completion:^{}];
 		else
-			[[self parentViewController] dismissModalViewControllerAnimated:YES];
+			[[self parentViewController] dismissViewControllerAnimated:YES completion:^{}];
 	}
 }
 
@@ -315,7 +315,7 @@ static const NSUInteger kDomainSection = 1;
 	}
 #endif
 
-	[[self presentingController] presentModalViewController:self animated:YES];
+	[[self presentingController] presentViewController:self animated:YES completion:^{}];
 }
 
 #pragma mark button callbacks

--- a/Classes/ASIDataCompressor.m
+++ b/Classes/ASIDataCompressor.m
@@ -161,7 +161,7 @@
 		readLength = [inputStream read:inputData maxLength:DATA_CHUNK_SIZE];
 
 		// Make sure nothing went wrong
-		if ([inputStream streamStatus] == NSStreamEventErrorOccurred) {
+		if ([inputStream streamStatus] == NSStreamStatusError) {
 			if (err) {
 				*err = [NSError errorWithDomain:NetworkRequestErrorDomain code:ASICompressionError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Compression of %@ failed because we were unable to read from the source data file",sourcePath],NSLocalizedDescriptionKey,[inputStream streamError],NSUnderlyingErrorKey,nil]];
 			}
@@ -187,7 +187,7 @@
 		[outputStream write:(const uint8_t *)[outputData bytes] maxLength:[outputData length]];
 		
 		// Make sure nothing went wrong
-		if ([inputStream streamStatus] == NSStreamEventErrorOccurred) {
+		if ([inputStream streamStatus] == NSStreamStatusError) {
 			if (err) {
 				*err = [NSError errorWithDomain:NetworkRequestErrorDomain code:ASICompressionError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Compression of %@ failed because we were unable to write to the destination data file at %@",sourcePath,destinationPath],NSLocalizedDescriptionKey,[outputStream streamError],NSUnderlyingErrorKey,nil]];
             }

--- a/Classes/ASIDataDecompressor.m
+++ b/Classes/ASIDataDecompressor.m
@@ -158,7 +158,7 @@
 		readLength = [inputStream read:inputData maxLength:DATA_CHUNK_SIZE]; 
 		
 		// Make sure nothing went wrong
-		if ([inputStream streamStatus] == NSStreamEventErrorOccurred) {
+		if ([inputStream streamStatus] == NSStreamStatusError) {
 			if (err) {
 				*err = [NSError errorWithDomain:NetworkRequestErrorDomain code:ASICompressionError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Decompression of %@ failed because we were unable to read from the source data file",sourcePath],NSLocalizedDescriptionKey,[inputStream streamError],NSUnderlyingErrorKey,nil]];
 			}
@@ -184,7 +184,7 @@
 		[outputStream write:(Bytef*)[outputData bytes] maxLength:[outputData length]];
 		
 		// Make sure nothing went wrong
-		if ([inputStream streamStatus] == NSStreamEventErrorOccurred) {
+		if ([inputStream streamStatus] == NSStreamStatusError) {
 			if (err) {
 				*err = [NSError errorWithDomain:NetworkRequestErrorDomain code:ASICompressionError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Decompression of %@ failed because we were unable to write to the destination data file at %@",sourcePath,destinationPath],NSLocalizedDescriptionKey,[outputStream streamError],NSUnderlyingErrorKey,nil]];
             }

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -4866,7 +4866,7 @@ static NSOperationQueue *sharedQueue = nil;
   
 	// RFC 2612 says max-age must override any Expires header
 	if (maxAge) {
-		return [[NSDate date] addTimeInterval:maxAge];
+		return [[NSDate date] dateByAddingTimeInterval:maxAge];
 	} else {
 		NSString *expires = [responseHeaders objectForKey:@"Expires"];
 		if (expires) {

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -1211,17 +1211,19 @@ static NSOperationQueue *sharedQueue = nil;
         if (![self validatesSecureCertificate]) {
             // see: http://iphonedevelopment.blogspot.com/2010/05/nsstream-tcp-and-ssl.html
             
-            NSDictionary *sslProperties = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                      [NSNumber numberWithBool:YES], kCFStreamSSLAllowsExpiredCertificates,
-                                      [NSNumber numberWithBool:YES], kCFStreamSSLAllowsAnyRoot,
-                                      [NSNumber numberWithBool:NO],  kCFStreamSSLValidatesCertificateChain,
-                                      kCFNull,kCFStreamSSLPeerName,
-                                      nil];
+        		// This is deprecated and we don't need it for now
+
+            // NSDictionary *sslProperties = [[NSDictionary alloc] initWithObjectsAndKeys:
+            //                           [NSNumber numberWithBool:YES], kCFStreamSSLAllowsExpiredCertificates,
+            //                           [NSNumber numberWithBool:YES], kCFStreamSSLAllowsAnyRoot,
+            //                           [NSNumber numberWithBool:NO],  kCFStreamSSLValidatesCertificateChain,
+            //                           kCFNull,kCFStreamSSLPeerName,
+            //                           nil];
             
-            CFReadStreamSetProperty((CFReadStreamRef)[self readStream], 
-                                    kCFStreamPropertySSLSettings, 
-                                    (CFTypeRef)sslProperties);
-            [sslProperties release];
+            // CFReadStreamSetProperty((CFReadStreamRef)[self readStream], 
+            //                         kCFStreamPropertySSLSettings, 
+            //                         (CFTypeRef)sslProperties);
+            // [sslProperties release];
         } 
         
         // Tell CFNetwork to use a client certificate


### PR DESCRIPTION
Instead of walking each file and deleting it on the current thread, we move the cache directory to a uniquely-named directory in the temp directory and delete its contents on a background thread.  For whatever reason the iOS filesystem can perform a rename very quickly but deletes - especially for larger files, e.g. images - can be very slow (orders of magnitude slower) on old devices like the iPad 1.

This approach should be safe even if the background deletion thread is unable to complete normally (e.g. the application is unexpected terminated during execution) because we can rely on the system to clean up for us eventually since we're operating on files in the temp directory.

ASIHTTPRequest is a great library and I have used it to build some high-traffic apps.  Unfortunately I was really bitten by the cache-clearing performance on older devices.  Users were unable to start up the app due to being killed by the iOS watchdog since the deletes took so long to execute.  In our app, this call might have taken 20 seconds in the pathological case (!) on an iPad 1.  Now it takes about 100ms.

Another way to address this would be to allow client code to specify ASIDownloadCache size/item limits, with some kind of LRU eviction.  But this was a quicker, less invasive win for me.
