### PR TITLE
Fix missing copied blocks

### DIFF
--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -4099,6 +4099,19 @@ static NSOperationQueue *sharedQueue = nil;
 	[newRequest setShouldAttemptPersistentConnection:[self shouldAttemptPersistentConnection]];
 	[newRequest setPersistentConnectionTimeoutSeconds:[self persistentConnectionTimeoutSeconds]];
     [newRequest setAuthenticationScheme:[self authenticationScheme]];
+#if NS_BLOCKS_AVAILABLE
+    [newRequest setStartedBlock:startedBlock];
+    [newRequest setHeadersReceivedBlock:headersReceivedBlock];
+    [newRequest setCompletionBlock:completionBlock];
+    [newRequest setBytesReceivedBlock:bytesReceivedBlock];
+    [newRequest setBytesSentBlock:bytesSentBlock];
+    [newRequest setDownloadSizeIncrementedBlock:downloadSizeIncrementedBlock];
+    [newRequest setUploadSizeIncrementedBlock:uploadSizeIncrementedBlock];
+    [newRequest setDataReceivedBlock:dataReceivedBlock];
+    [newRequest setAuthenticationNeededBlock:authenticationNeededBlock];
+    [newRequest setProxyAuthenticationNeededBlock:proxyAuthenticationNeededBlock];
+    [newRequest setRequestRedirectedBlock:requestRedirectedBlock];
+#endif
 	return newRequest;
 }
 

--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -4103,6 +4103,7 @@ static NSOperationQueue *sharedQueue = nil;
     [newRequest setStartedBlock:startedBlock];
     [newRequest setHeadersReceivedBlock:headersReceivedBlock];
     [newRequest setCompletionBlock:completionBlock];
+    [newRequest setFailedBlock:failureBlock];
     [newRequest setBytesReceivedBlock:bytesReceivedBlock];
     [newRequest setBytesSentBlock:bytesSentBlock];
     [newRequest setDownloadSizeIncrementedBlock:downloadSizeIncrementedBlock];


### PR DESCRIPTION
Hey!

If you copied a request, blocks aren't copied so it caused blocks didn't get fired on it!

Thanks!
