### PR TITLE
Creating path of downloaded file if it doesn't exist

### DIFF
--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -3446,6 +3446,16 @@ static NSOperationQueue *sharedQueue = nil;
 
 			// Response should already have been inflated, move the temporary file to the destination path
 			} else {
+				NSError *tmperror;
+                
+		                if (![[NSFileManager defaultManager] fileExistsAtPath:[self downloadDestinationPath]]) {
+		                    [[NSFileManager defaultManager] createDirectoryAtPath:[self downloadDestinationPath]
+		                                              withIntermediateDirectories:YES
+		                                                               attributes:nil
+		                                                                    error:&tmperror];
+		                }
+                		[[NSFileManager defaultManager] removeItemAtPath:[self downloadDestinationPath] error:nil];
+                
 				NSError *moveError = nil;
 				[[[[NSFileManager alloc] init] autorelease] moveItemAtPath:[self temporaryUncompressedDataDownloadPath] toPath:[self downloadDestinationPath] error:&moveError];
 				if (moveError) {
@@ -3467,6 +3477,16 @@ static NSOperationQueue *sharedQueue = nil;
 
 			//Move the temporary file to the destination path
 			if (!fileError) {
+				NSError *tmperror;
+                
+		                if (![[NSFileManager defaultManager] fileExistsAtPath:[self downloadDestinationPath]]) {
+		                    [[NSFileManager defaultManager] createDirectoryAtPath:[self downloadDestinationPath]
+		                                              withIntermediateDirectories:YES
+		                                                               attributes:nil
+		                                                                    error:&tmperror];
+		                }
+                		[[NSFileManager defaultManager] removeItemAtPath:[self downloadDestinationPath] error:nil];
+                		
 				[[[[NSFileManager alloc] init] autorelease] moveItemAtPath:[self temporaryFileDownloadPath] toPath:[self downloadDestinationPath] error:&moveError];
 				if (moveError) {
 					fileError = [NSError errorWithDomain:NetworkRequestErrorDomain code:ASIFileManagementError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Failed to move file from '%@' to '%@'",[self temporaryFileDownloadPath],[self downloadDestinationPath]],NSLocalizedDescriptionKey,moveError,NSUnderlyingErrorKey,nil]];


### PR DESCRIPTION
Creating path of downloaded file if it doesn't exist.

If you download a file to a non-existing location the download fails. This pull-request fixes that issue.
