### PR TITLE
update two deprecated methods to up-to-date version

### DIFF
--- a/Classes/ASIAuthenticationDialog.m
+++ b/Classes/ASIAuthenticationDialog.m
@@ -217,9 +217,9 @@ static const NSUInteger kDomainSection = 1;
 + (void)dismiss
 {
 	if ([sharedDialog respondsToSelector:@selector(presentingViewController)])
-		[[sharedDialog presentingViewController] dismissModalViewControllerAnimated:YES];
+		[[sharedDialog presentingViewController] dismissViewControllerAnimated:YES completion:nil];
 	else 
-		[[sharedDialog parentViewController] dismissModalViewControllerAnimated:YES];
+		[[sharedDialog parentViewController] dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)viewDidDisappear:(BOOL)animated
@@ -237,9 +237,9 @@ static const NSUInteger kDomainSection = 1;
 		[[self class] dismiss];
 	} else {
 		if ([self respondsToSelector:@selector(presentingViewController)])
-			[[self presentingViewController] dismissModalViewControllerAnimated:YES];
+			[[self presentingViewController] dismissViewControllerAnimated:YES completion:nil];
 		else
-			[[self parentViewController] dismissModalViewControllerAnimated:YES];
+			[[self parentViewController] dismissViewControllerAnimated:YES completion:nil];
 	}
 }
 
@@ -315,7 +315,7 @@ static const NSUInteger kDomainSection = 1;
 	}
 #endif
 
-	[[self presentingController] presentModalViewController:self animated:YES];
+	[[self presentingController] presentViewController:self animated:YES completion:nil];
 }
 
 #pragma mark button callbacks


### PR DESCRIPTION
update deprecated method to up-to-date version, dismissModalViewControllerAnimated: & presentModalViewController:animated:, to dismissViewControllerAnimated:completion: & presentViewController:animated:completion:.
