### PR TITLE
Fix NTLM Proxy authentication issues.

### DIFF
--- a/Classes/ASIHTTPRequest.m
+++ b/Classes/ASIHTTPRequest.m
@@ -2476,14 +2476,6 @@ static NSOperationQueue *sharedQueue = nil;
 		user = [self proxyUsername];
 		pass = [self proxyPassword];
 	}
-
-	// When we connect to a website using NTLM via a proxy, we will use the main credentials
-	if ((!user || !pass) && [self proxyAuthenticationScheme] == (NSString *)kCFHTTPAuthenticationSchemeNTLM) {
-		user = [self username];
-		pass = [self password];
-	}
-
-
 	
 	// Ok, that didn't work, let's try the keychain
 	// For authenticating proxies, we'll look in the keychain regardless of the value of useKeychainPersistence
@@ -2494,6 +2486,13 @@ static NSOperationQueue *sharedQueue = nil;
 			pass = [authenticationCredentials password];
 		}
 		
+	}
+
+    // If proxy credential is still not available and when we connect to a website using NTLM via a proxy,
+    // we will use the main credentials
+	if ((!user || !pass) && [self proxyAuthenticationScheme] == (NSString *)kCFHTTPAuthenticationSchemeNTLM) {
+		user = [self username];
+		pass = [self password];
 	}
 
 	// Handle NTLM, which requires a domain to be set too
@@ -2843,12 +2842,15 @@ static NSOperationQueue *sharedQueue = nil;
 	
 	if (proxyCredentials) {
 		
+        // From wireshark logs, proxy auth challenge is not responded by calling startRequest twice.
+        // Needed a third call to get the auth challenge response sent.
+        
 		// We use startRequest rather than starting all over again in load request because NTLM requires we reuse the request
-		if ((([self proxyAuthenticationScheme] != (NSString *)kCFHTTPAuthenticationSchemeNTLM) || [self proxyAuthenticationRetryCount] < 2) && [self applyProxyCredentials:proxyCredentials]) {
+		if ((([self proxyAuthenticationScheme] != (NSString *)kCFHTTPAuthenticationSchemeNTLM) || [self proxyAuthenticationRetryCount] < 3) && [self applyProxyCredentials:proxyCredentials]) {
 			[self startRequest];
 			
 		// We've failed NTLM authentication twice, we should assume our credentials are wrong
-		} else if ([self proxyAuthenticationScheme] == (NSString *)kCFHTTPAuthenticationSchemeNTLM && [self proxyAuthenticationRetryCount] == 2) {
+		} else if ([self proxyAuthenticationScheme] == (NSString *)kCFHTTPAuthenticationSchemeNTLM && [self proxyAuthenticationRetryCount] == 3) {
 			[self failWithError:ASIAuthenticationError];
 			
 		// Something went wrong, we'll have to give up


### PR DESCRIPTION
I found two issues when authenticating against NTLM Proxy on Mac OSX.  I am testing AsiHttpRequest with Microsoft Forefront TMG server as the proxy.

Issue 1) Http request's user credential is used for proxy credential.

For most use cases, user will have proxy credential stored in the keychain.
Look for credential in keychain first, then use the http request credential.

Issue 2) From wireshark network traces, calling startRequest twice does not
actually send the NTLM proxy auth challenge response.  The third startRequest
will send the auth challenge response and get past the proxy authentication.

There must be a different root cause for not responding for the NTLM auth challenge with the original code.  By making the 3rd startRequest call, I can workaround this issue, however.
